### PR TITLE
Add v4 Embedding Layout view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ function IndexPage() {
       <section id="center">
         <div>
           <h1>egregorigami</h1>
-          <p>Explorations in collective intelligence and machine perception.</p>
+          <p>Explorations of collective intelligence, narrative space, and protein folding.</p>
         </div>
         <ul className="app-list">
           <li>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import TranscriptViewer from './TranscriptViewer'
 import YoutubeTranscriptViewer from './YoutubeTranscriptViewer'
 import YoutubeEmbeddingProjector from './YoutubeEmbeddingProjector'
+import EmbeddingLayoutView from './EmbeddingLayoutView'
 import './App.css'
 
 function useHash() {
@@ -41,6 +42,12 @@ function IndexPage() {
               <span>Generate sentence embeddings in-browser and explore the 3D semantic space with an interactive scatter plot.</span>
             </a>
           </li>
+          <li>
+            <a href="#v4">
+              <strong>Embedding Layout</strong>
+              <span>Side-by-side view: YouTube player and transcript with an inline 3D embedding panel.</span>
+            </a>
+          </li>
         </ul>
       </section>
       <div className="ticks"></div>
@@ -54,6 +61,7 @@ function App() {
   if (hash === '#v1') return <TranscriptViewer />
   if (hash === '#v2') return <YoutubeTranscriptViewer />
   if (hash === '#v3') return <YoutubeEmbeddingProjector />
+  if (hash === '#v4') return <EmbeddingLayoutView />
   return <IndexPage />
 }
 

--- a/src/EmbeddingLayoutView.css
+++ b/src/EmbeddingLayoutView.css
@@ -1,0 +1,130 @@
+.embedding-layout-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.embedding-layout-bar {
+  flex-shrink: 0;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.embedding-layout-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.embedding-layout-panels {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.embedding-layout-left {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.embedding-layout-right {
+  width: 420px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.embedding-panel-placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 32px 24px;
+  color: var(--text);
+  opacity: 0.5;
+  font-size: 14px;
+  text-align: center;
+}
+
+.embedding-panel-form {
+  flex-shrink: 0;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.embedding-panel-form-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.embedding-panel-scatter {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.embedding-panel-progress {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 24px;
+  gap: 16px;
+}
+
+.show-segments-btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--code-bg);
+  color: var(--text-h);
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.show-segments-btn:hover {
+  background: var(--border);
+}
+
+.run-embedding-btn {
+  padding: 8px 18px;
+  border-radius: 6px;
+  border: none;
+  background: var(--accent);
+  color: #fff;
+  font-size: 14px;
+  cursor: pointer;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.run-embedding-btn:hover {
+  opacity: 0.88;
+}
+
+.embedding-panel-error {
+  color: #e53e3e;
+  font-size: 13px;
+  margin: 0;
+  padding: 12px 16px;
+}

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -89,6 +89,12 @@ export default function EmbeddingLayoutView() {
     setHasTranscriptText(!!params.text.trim())
   }, [])
 
+  const handleParamsBlur = useCallback(() => {
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    if (!text.trim()) return
+    setSegments(computeChunks(text, windowSize, overlapPct))
+  }, [])
+
   // Embedding state
   const [selectedModel, setSelectedModel] = useState<EmbeddingModelId>(() => {
     const stored = localStorage.getItem('projector-model')
@@ -129,7 +135,8 @@ export default function EmbeddingLayoutView() {
       setLoadStatus('idle')
       // Reset embedding state when new transcript loaded
       setEmbedPhase({ status: 'idle' })
-      setSegments(null)
+      const { windowSize, overlapPct } = windowParamsRef.current
+      setSegments(computeChunks(text, windowSize, overlapPct))
     } catch (e) {
       setLoadStatus('error')
       setLoadError(String(e))
@@ -269,6 +276,7 @@ export default function EmbeddingLayoutView() {
             initialText={loadedText ?? undefined}
             initialDuration={loadedDuration ?? undefined}
             onWindowChange={handleWindowChange}
+            onParamsBlur={handleParamsBlur}
             externalPosition={externalPosition}
             externalPlaying={ytPlaying}
             onScrub={handleScrub}

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -454,6 +454,19 @@ export default function EmbeddingLayoutView() {
           {isDone && embedPhase.status === 'done' && segments && (
             <>
               <div className="embedding-panel-form" style={{ flexShrink: 0 }}>
+                <select
+                  className="model-select"
+                  value={selectedModel}
+                  onChange={e => {
+                    const v = e.target.value as EmbeddingModelId
+                    setSelectedModel(v)
+                    localStorage.setItem('projector-model', v)
+                  }}
+                >
+                  {EMBEDDING_MODELS.map(m => (
+                    <option key={m.id} value={m.id}>{m.label}</option>
+                  ))}
+                </select>
                 <div className="embedding-panel-form-row">
                   <button className="show-segments-btn" onClick={handleShowSegments}>
                     Show Segments ({segments.length})
@@ -462,7 +475,7 @@ export default function EmbeddingLayoutView() {
                     className="run-embedding-btn"
                     onClick={handleRunEmbedding}
                   >
-                    Re-run
+                    Run Embedding
                   </button>
                 </div>
               </div>

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -1,0 +1,406 @@
+import { useState, useRef, useCallback } from 'react'
+import TranscriptViewer from './TranscriptViewer'
+import YoutubePlayerEmbed from './YoutubePlayerEmbed'
+import ScatterPlot3D from './ScatterPlot3D'
+import SegmentsListModal from './SegmentsListModal'
+import { getEmbeddings, EMBEDDING_MODELS, type EmbeddingModelId } from './embedSegments'
+import { runUmap } from './runUmap'
+import './YoutubeTranscriptViewer.css'
+import './SegmentProjectorModal.css'
+import './EmbeddingLayoutView.css'
+
+function extractVideoId(url: string): string | null {
+  try {
+    const u = new URL(url.trim())
+    if (u.hostname === 'youtu.be') return u.pathname.slice(1)
+    if (u.hostname.includes('youtube.com')) return u.searchParams.get('v')
+    return null
+  } catch {
+    return /^[a-zA-Z0-9_-]{11}$/.test(url.trim()) ? url.trim() : null
+  }
+}
+
+function buildTranscriptData(segments: Array<{ text: string; offset: number }>): {
+  text: string
+  wordTimestamps: number[]
+} {
+  const words: string[] = []
+  const timestamps: number[] = []
+  for (const seg of segments) {
+    const segWords = seg.text.trim().split(/\s+/).filter(Boolean)
+    for (const w of segWords) {
+      words.push(w)
+      timestamps.push(seg.offset)
+    }
+  }
+  return { text: words.join(' '), wordTimestamps: timestamps }
+}
+
+function computeChunks(text: string, windowSize: number, overlapPct: number): string[] {
+  const words = text.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return []
+  const step = Math.max(1, Math.round(windowSize * (1 - overlapPct / 100)))
+  const chunks: string[] = []
+  for (let cursor = Math.min(windowSize - 1, words.length - 1); cursor < words.length; cursor += step) {
+    const windowStart = Math.max(0, cursor - windowSize + 1)
+    chunks.push(words.slice(windowStart, windowStart + windowSize).join(' '))
+  }
+  return chunks
+}
+
+type EmbedPhase =
+  | { status: 'idle' }
+  | { status: 'model-loading'; progress: number }
+  | { status: 'embedding'; loaded: number; total: number }
+  | { status: 'umap-running' }
+  | { status: 'done'; points: [number, number, number][] }
+  | { status: 'error'; message: string }
+
+const isProd = import.meta.env.PROD
+
+export default function EmbeddingLayoutView() {
+  const [urlInput, setUrlInput] = useState(() => localStorage.getItem('yt-url') ?? '')
+  const [loadedText, setLoadedText] = useState<string | null>(() => localStorage.getItem('yt-transcript'))
+  const [loadedDuration, setLoadedDuration] = useState<string | null>(() => localStorage.getItem('yt-duration'))
+  const [loadedVideoId, setLoadedVideoId] = useState<string | null>(() =>
+    extractVideoId(localStorage.getItem('yt-url') ?? '') ? localStorage.getItem('yt-video-id') : null
+  )
+  const [loadCount, setLoadCount] = useState(0)
+  const [loadStatus, setLoadStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+  const [loadError, setLoadError] = useState('')
+  const [wordTimestamps, setWordTimestamps] = useState<number[] | null>(
+    () => JSON.parse(localStorage.getItem('yt-word-timestamps') ?? 'null')
+  )
+  const [videoTime, setVideoTime] = useState(0)
+  const [seekTarget, setSeekTarget] = useState<number | undefined>(undefined)
+  const [transcriptPlaying, setTranscriptPlaying] = useState(false)
+  const [ytPlaying, setYtPlaying] = useState(false)
+  const [playbackRate, setPlaybackRate] = useState(1)
+
+  const [hasTranscriptText, setHasTranscriptText] = useState(() => !!(loadedText?.trim()))
+  const windowParamsRef = useRef<{ windowSize: number; overlapPct: number; text: string }>({
+    windowSize: 20,
+    overlapPct: 50,
+    text: loadedText ?? '',
+  })
+
+  const handleWindowChange = useCallback((params: { windowSize: number; overlapPct: number; text: string }) => {
+    windowParamsRef.current = params
+    setHasTranscriptText(!!params.text.trim())
+  }, [])
+
+  // Embedding state
+  const [selectedModel, setSelectedModel] = useState<EmbeddingModelId>(() => {
+    const stored = localStorage.getItem('projector-model')
+    return (EMBEDDING_MODELS.find(m => m.id === stored) ?? EMBEDDING_MODELS.find(m => m.default)!).id
+  })
+  const [embedPhase, setEmbedPhase] = useState<EmbedPhase>({ status: 'idle' })
+  const [segments, setSegments] = useState<string[] | null>(null)
+  const [showSegmentsModal, setShowSegmentsModal] = useState(false)
+
+  // Scatter highlight state
+  const [highlightIndex, setHighlightIndex] = useState<number | null>(null)
+
+  const handleLoad = async () => {
+    const videoId = extractVideoId(urlInput)
+    if (!videoId) {
+      setLoadStatus('error')
+      setLoadError('Could not extract a video ID from the input.')
+      return
+    }
+    setLoadStatus('loading')
+    setLoadError('')
+    try {
+      const res = await fetch(`/api/transcript?videoId=${encodeURIComponent(videoId)}`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`)
+      const { text, wordTimestamps } = buildTranscriptData(data.segments)
+      const duration = String(Math.round(data.totalDuration))
+      setLoadedText(text)
+      setLoadedDuration(duration)
+      setLoadedVideoId(videoId)
+      setWordTimestamps(wordTimestamps)
+      setLoadCount(c => c + 1)
+      localStorage.setItem('yt-url', urlInput)
+      localStorage.setItem('yt-transcript', text)
+      localStorage.setItem('yt-duration', duration)
+      localStorage.setItem('yt-video-id', videoId)
+      localStorage.setItem('yt-word-timestamps', JSON.stringify(wordTimestamps))
+      setLoadStatus('idle')
+      // Reset embedding state when new transcript loaded
+      setEmbedPhase({ status: 'idle' })
+      setSegments(null)
+    } catch (e) {
+      setLoadStatus('error')
+      setLoadError(String(e))
+    }
+  }
+
+  const totalSecs = loadedDuration ? parseInt(loadedDuration) : null
+
+  const externalPosition = (() => {
+    if (!totalSecs) return undefined
+    if (wordTimestamps && wordTimestamps.length > 1) {
+      if (videoTime < wordTimestamps[0]) return 0
+      let segFirstIdx = 0
+      for (let i = 1; i < wordTimestamps.length; i++) {
+        if (wordTimestamps[i] > videoTime) break
+        if (wordTimestamps[i] > wordTimestamps[i - 1]) segFirstIdx = i
+      }
+      let segLastIdx = segFirstIdx
+      while (segLastIdx + 1 < wordTimestamps.length && wordTimestamps[segLastIdx + 1] === wordTimestamps[segFirstIdx]) {
+        segLastIdx++
+      }
+      const segStart = wordTimestamps[segFirstIdx]
+      const nextSegStart = segLastIdx + 1 < wordTimestamps.length ? wordTimestamps[segLastIdx + 1] : totalSecs
+      const segDuration = nextSegStart - segStart
+      const segWordCount = segLastIdx - segFirstIdx + 1
+      const wordOffset = segDuration > 0
+        ? Math.min(Math.floor(((videoTime - segStart) / segDuration) * segWordCount), segWordCount - 1)
+        : 0
+      return (segFirstIdx + wordOffset) / (wordTimestamps.length - 1)
+    }
+    return videoTime / totalSecs
+  })()
+
+  const handleScrub = useCallback((pos: number) => {
+    if (!totalSecs) return
+    const t = pos * totalSecs
+    setVideoTime(t)
+    setSeekTarget(t)
+  }, [totalSecs])
+
+  const runEmbeddingOnChunks = async (chunks: string[]) => {
+    if (chunks.length === 0) return
+    setEmbedPhase({ status: 'model-loading', progress: 0 })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    try {
+      const vectors = await getEmbeddings(chunks, (loaded, total, phaseLabel) => {
+        if (phaseLabel === 'model-loading') {
+          setEmbedPhase({ status: 'model-loading', progress: loaded })
+        } else {
+          setEmbedPhase({ status: 'embedding', loaded, total })
+        }
+      }, selectedModel)
+      setEmbedPhase({ status: 'umap-running' })
+      await new Promise(resolve => setTimeout(resolve, 0))
+      const points = runUmap(vectors)
+      setEmbedPhase({ status: 'done', points })
+    } catch (e) {
+      setEmbedPhase({ status: 'error', message: String(e) })
+    }
+  }
+
+  const handleRunEmbedding = () => {
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    const chunks = computeChunks(text, windowSize, overlapPct)
+    setSegments(chunks)
+    runEmbeddingOnChunks(chunks)
+  }
+
+  const handleShowSegments = () => {
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    const chunks = computeChunks(text, windowSize, overlapPct)
+    setSegments(chunks)
+    setShowSegmentsModal(true)
+  }
+
+  const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status === 'embedding' || embedPhase.status === 'umap-running'
+  const isDone = embedPhase.status === 'done'
+
+  const currentVideoId = extractVideoId(urlInput)
+  const transcriptToolUrl = currentVideoId
+    ? `https://www.youtube-transcript.io/videos?id=${currentVideoId}`
+    : 'https://www.youtube-transcript.io'
+
+  return (
+    <div className="embedding-layout-wrapper">
+      {/* URL Bar */}
+      <div className="embedding-layout-bar">
+        <div className="embedding-layout-row">
+          <input
+            type="url"
+            className="youtube-url-input"
+            value={urlInput}
+            onChange={e => {
+              const val = e.target.value
+              setUrlInput(val)
+              localStorage.setItem('yt-url', val)
+              if (!extractVideoId(val)) {
+                setLoadedVideoId(null)
+                setWordTimestamps(null)
+                localStorage.removeItem('yt-word-timestamps')
+              }
+            }}
+            onKeyDown={e => { if (e.key === 'Enter' && !isProd) handleLoad() }}
+            placeholder="https://www.youtube.com/watch?v=..."
+          />
+          <button className="yt-action-btn" onClick={handleLoad} disabled={isProd || loadStatus === 'loading'}>
+            {loadStatus === 'loading' ? 'Loading…' : 'Load'}
+          </button>
+        </div>
+        {loadStatus === 'error' && <p className="youtube-error">{loadError}</p>}
+        {isProd && (
+          <p className="youtube-notice">
+            {currentVideoId
+              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Get the transcript for this video ↗</a> then paste it into the text area below.</>
+              : <>Paste a YouTube URL above to get started.</>
+            }
+          </p>
+        )}
+      </div>
+
+      {/* Main panels */}
+      <div className="embedding-layout-panels">
+        {/* Left: video + transcript */}
+        <div className="embedding-layout-left">
+          {loadedVideoId && totalSecs && (
+            <YoutubePlayerEmbed
+              videoId={loadedVideoId}
+              onTimeUpdate={setVideoTime}
+              seekTo={seekTarget}
+              playing={transcriptPlaying}
+              onPlayStateChange={setYtPlaying}
+              playbackRate={playbackRate}
+            />
+          )}
+          <TranscriptViewer
+            key={`${loadedVideoId ?? 'empty'}-${loadCount}`}
+            initialText={loadedText ?? undefined}
+            initialDuration={loadedDuration ?? undefined}
+            onWindowChange={handleWindowChange}
+            externalPosition={externalPosition}
+            externalPlaying={ytPlaying}
+            onScrub={handleScrub}
+            onPlayingChange={setTranscriptPlaying}
+            onSpeedChange={setPlaybackRate}
+            maxSpeed={loadedVideoId ? 2 : undefined}
+          />
+        </div>
+
+        {/* Right: embedding panel */}
+        <div className="embedding-layout-right">
+          {/* No transcript yet */}
+          {!hasTranscriptText && (
+            <div className="embedding-panel-placeholder">
+              <span>Load a YouTube video to enable embedding.</span>
+            </div>
+          )}
+
+          {/* Transcript available, not yet embedded */}
+          {hasTranscriptText && !isDone && !isEmbedding && (
+            <>
+              <div className="embedding-panel-form">
+                <select
+                  className="model-select"
+                  value={selectedModel}
+                  onChange={e => {
+                    const v = e.target.value as EmbeddingModelId
+                    setSelectedModel(v)
+                    localStorage.setItem('projector-model', v)
+                  }}
+                >
+                  {EMBEDDING_MODELS.map(m => (
+                    <option key={m.id} value={m.id}>{m.label}</option>
+                  ))}
+                </select>
+                <div className="embedding-panel-form-row">
+                  <button
+                    className="run-embedding-btn"
+                    onClick={handleRunEmbedding}
+                  >
+                    Run Embedding
+                  </button>
+                  <button className="show-segments-btn" onClick={handleShowSegments}>
+                    Show Segments{segments ? ` (${segments.length})` : ''}
+                  </button>
+                </div>
+                {embedPhase.status === 'error' && (
+                  <p className="embedding-panel-error">{embedPhase.message}</p>
+                )}
+              </div>
+              {!segments && (
+                <div className="embedding-panel-placeholder">
+                  <span>Run embedding to visualize segment relationships in 3D.</span>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Embedding in progress */}
+          {isEmbedding && (
+            <div className="embedding-panel-progress">
+              {embedPhase.status === 'model-loading' && (
+                <div className="progress-wrap" style={{ width: '100%', maxWidth: 300 }}>
+                  <div className="progress-label">
+                    <div className="spinner" />
+                    <span>{embedPhase.progress > 0 ? `Downloading model… ${embedPhase.progress}%` : 'Initializing model…'}</span>
+                  </div>
+                  <div className={`progress-bar ${embedPhase.progress === 0 ? 'progress-bar--indeterminate' : ''}`}>
+                    <div className="progress-bar-fill" style={{ width: `${embedPhase.progress}%` }} />
+                  </div>
+                </div>
+              )}
+              {embedPhase.status === 'embedding' && (
+                <div className="progress-wrap" style={{ width: '100%', maxWidth: 300 }}>
+                  <div className="progress-label">
+                    <div className="spinner" />
+                    <span>Embedding {embedPhase.loaded + 1} / {embedPhase.total}</span>
+                  </div>
+                  <div className="progress-bar">
+                    <div className="progress-bar-fill" style={{ width: `${(embedPhase.loaded / embedPhase.total) * 100}%` }} />
+                  </div>
+                </div>
+              )}
+              {embedPhase.status === 'umap-running' && (
+                <div className="progress-wrap" style={{ width: '100%', maxWidth: 300 }}>
+                  <div className="progress-label">
+                    <div className="spinner" />
+                    <span>Reducing to 3D…</span>
+                  </div>
+                  <div className="progress-bar progress-bar--indeterminate">
+                    <div className="progress-bar-fill" />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Embedding done */}
+          {isDone && embedPhase.status === 'done' && segments && (
+            <>
+              <div className="embedding-panel-form" style={{ flexShrink: 0 }}>
+                <div className="embedding-panel-form-row">
+                  <button className="show-segments-btn" onClick={handleShowSegments}>
+                    Show Segments ({segments.length})
+                  </button>
+                  <button
+                    className="run-embedding-btn"
+                    onClick={handleRunEmbedding}
+                  >
+                    Re-run
+                  </button>
+                </div>
+              </div>
+              <div className="embedding-panel-scatter">
+                <ScatterPlot3D
+                  points={embedPhase.points}
+                  labels={segments}
+                  highlightPosition={highlightIndex}
+                  onPointClick={idx => setHighlightIndex(idx)}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {showSegmentsModal && segments && (
+        <SegmentsListModal
+          segments={segments}
+          onClose={() => setShowSegmentsModal(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -169,6 +169,24 @@ export default function EmbeddingLayoutView() {
     }
   }, [])
 
+  const handlePointClick = useCallback((idx: number) => {
+    setHighlightIndex(idx)
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    const words = text.trim().split(/\s+/).filter(Boolean)
+    if (words.length === 0) return
+    const step = Math.max(1, Math.round(windowSize * (1 - overlapPct / 100)))
+    const initialCursor = Math.min(windowSize - 1, words.length - 1)
+    const wordIndex = Math.min(words.length - 1, initialCursor + idx * step)
+    const ts = wordTimestampsRef.current
+    const secs = totalSecsRef.current
+    if (!secs) return
+    const seekTime = ts && ts.length > 0
+      ? ts[Math.min(wordIndex, ts.length - 1)]
+      : (words.length > 1 ? (wordIndex / (words.length - 1)) * secs : 0)
+    setVideoTime(seekTime)
+    setSeekTarget(seekTime)
+  }, [])
+
   const handleLoad = async () => {
     const videoId = extractVideoId(urlInput)
     if (!videoId) {
@@ -484,7 +502,7 @@ export default function EmbeddingLayoutView() {
                   points={embedPhase.points}
                   labels={segments}
                   highlightPosition={highlightIndex}
-                  onPointClick={idx => setHighlightIndex(idx)}
+                  onPointClick={handlePointClick}
                 />
               </div>
             </>

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -119,16 +119,30 @@ export default function EmbeddingLayoutView() {
     if (words.length === 0) return
     const step = Math.max(1, Math.round(windowSize * (1 - overlapPct / 100)))
     const initialCursor = Math.min(windowSize - 1, words.length - 1)
-    let bestIdx = 0
-    let bestDist = Infinity
-    for (let i = 0; i < segs.length; i++) {
+
+    // Compute end word index for each segment
+    const endIndices = segs.map((_, i) => {
       const cursor = Math.min(words.length - 1, initialCursor + i * step)
       const windowStart = Math.max(0, cursor - windowSize + 1)
-      const endIdx = Math.min(words.length - 1, windowStart + windowSize - 1)
-      const dist = Math.abs(endIdx - wordIndex)
-      if (dist < bestDist) { bestDist = dist; bestIdx = i }
+      return Math.min(words.length - 1, windowStart + windowSize - 1)
+    })
+
+    // Interpolate: find the two adjacent segments whose ends bracket wordIndex
+    if (wordIndex <= endIndices[0]) {
+      setHighlightIndex(0)
+      return
     }
-    setHighlightIndex(bestIdx)
+    if (wordIndex >= endIndices[endIndices.length - 1]) {
+      setHighlightIndex(segs.length - 1)
+      return
+    }
+    for (let i = 0; i < endIndices.length - 1; i++) {
+      if (wordIndex >= endIndices[i] && wordIndex < endIndices[i + 1]) {
+        const t = (wordIndex - endIndices[i]) / (endIndices[i + 1] - endIndices[i])
+        setHighlightIndex(i + t)
+        return
+      }
+    }
   }, [])
 
   const handleLoad = async () => {

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -107,6 +107,7 @@ export default function EmbeddingLayoutView() {
 
   // Scatter highlight state
   const [highlightIndex, setHighlightIndex] = useState<number | null>(null)
+  const [clickSeekPosition, setClickSeekPosition] = useState<number | undefined>(undefined)
   const segmentsRef = useRef<string[] | null>(null)
   const currentWordIndexRef = useRef(0)
   const wordTimestampsRef = useRef(wordTimestamps)
@@ -177,9 +178,13 @@ export default function EmbeddingLayoutView() {
     const step = Math.max(1, Math.round(windowSize * (1 - overlapPct / 100)))
     const initialCursor = Math.min(windowSize - 1, words.length - 1)
     const wordIndex = Math.min(words.length - 1, initialCursor + idx * step)
-    const ts = wordTimestampsRef.current
+    // Always set a direct word-index position so the transcript cursor jumps
+    // even when no video is loaded (externalPosition would otherwise be undefined)
+    setClickSeekPosition(words.length > 1 ? wordIndex / (words.length - 1) : 0)
+    // Also seek the video if available
     const secs = totalSecsRef.current
     if (!secs) return
+    const ts = wordTimestampsRef.current
     const seekTime = ts && ts.length > 0
       ? ts[Math.min(wordIndex, ts.length - 1)]
       : (words.length > 1 ? (wordIndex / (words.length - 1)) * secs : 0)
@@ -371,7 +376,7 @@ export default function EmbeddingLayoutView() {
             onParamsBlur={handleParamsBlur}
             onCursorChange={handleCursorChange}
             onAllowFasterChange={setAllowFaster}
-            externalPosition={allowFaster ? undefined : externalPosition}
+            externalPosition={(allowFaster ? undefined : externalPosition) ?? clickSeekPosition}
             externalPlaying={allowFaster ? undefined : ytPlaying}
             onScrub={handleScrub}
             onPlayingChange={setTranscriptPlaying}

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -76,6 +76,7 @@ export default function EmbeddingLayoutView() {
   const [transcriptPlaying, setTranscriptPlaying] = useState(false)
   const [ytPlaying, setYtPlaying] = useState(false)
   const [playbackRate, setPlaybackRate] = useState(1)
+  const [allowFaster, setAllowFaster] = useState(false)
 
   const [hasTranscriptText, setHasTranscriptText] = useState(() => !!(loadedText?.trim()))
   const windowParamsRef = useRef<{ windowSize: number; overlapPct: number; text: string }>({
@@ -107,11 +108,34 @@ export default function EmbeddingLayoutView() {
   // Scatter highlight state
   const [highlightIndex, setHighlightIndex] = useState<number | null>(null)
   const segmentsRef = useRef<string[] | null>(null)
+  const currentWordIndexRef = useRef(0)
+  const wordTimestampsRef = useRef(wordTimestamps)
+  useEffect(() => { wordTimestampsRef.current = wordTimestamps }, [wordTimestamps])
+  const totalSecsRef = useRef<number | null>(null)
 
   // Keep ref in sync so cursor handler always sees latest segments
   useEffect(() => { segmentsRef.current = segments }, [segments])
 
+  // When re-enabling YouTube player, seek it to where the transcript cursor ended up
+  const allowFasterPrevRef = useRef(false)
+  useEffect(() => {
+    if (!allowFaster && allowFasterPrevRef.current && totalSecsRef.current) {
+      const totalSecs = totalSecsRef.current
+      const wordIndex = currentWordIndexRef.current
+      const ts = wordTimestampsRef.current
+      const seekTime = ts && ts.length > 0
+        ? ts[Math.min(wordIndex, ts.length - 1)]
+        : (windowParamsRef.current.text.trim().split(/\s+/).filter(Boolean).length > 0
+            ? (wordIndex / windowParamsRef.current.text.trim().split(/\s+/).filter(Boolean).length) * totalSecs
+            : 0)
+      setVideoTime(seekTime)
+      setSeekTarget(seekTime)
+    }
+    allowFasterPrevRef.current = allowFaster
+  }, [allowFaster])
+
   const handleCursorChange = useCallback((wordIndex: number) => {
+    currentWordIndexRef.current = wordIndex
     const segs = segmentsRef.current
     if (!segs || segs.length === 0) return
     const { windowSize, overlapPct, text } = windowParamsRef.current
@@ -182,6 +206,7 @@ export default function EmbeddingLayoutView() {
   }
 
   const totalSecs = loadedDuration ? parseInt(loadedDuration) : null
+  totalSecsRef.current = totalSecs
 
   const externalPosition = (() => {
     if (!totalSecs) return undefined
@@ -300,14 +325,25 @@ export default function EmbeddingLayoutView() {
         {/* Left: video + transcript */}
         <div className="embedding-layout-left">
           {loadedVideoId && totalSecs && (
-            <YoutubePlayerEmbed
-              videoId={loadedVideoId}
-              onTimeUpdate={setVideoTime}
-              seekTo={seekTarget}
-              playing={transcriptPlaying}
-              onPlayStateChange={setYtPlaying}
-              playbackRate={playbackRate}
-            />
+            <div style={{ position: 'relative' }}>
+              <div style={{ visibility: allowFaster ? 'hidden' : 'visible' }}>
+                <YoutubePlayerEmbed
+                  videoId={loadedVideoId}
+                  onTimeUpdate={setVideoTime}
+                  seekTo={allowFaster ? undefined : seekTarget}
+                  playing={allowFaster ? false : transcriptPlaying}
+                  onPlayStateChange={allowFaster ? undefined : setYtPlaying}
+                  playbackRate={playbackRate}
+                />
+              </div>
+              {allowFaster && (
+                <div className="yt-player-container" style={{ position: 'absolute', inset: 0, margin: 0 }}>
+                  <div className="yt-player-aspect" style={{ background: 'var(--code-bg)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <span style={{ color: 'var(--text)', opacity: 0.4, fontSize: 13 }}>YouTube paused — allow faster enabled</span>
+                  </div>
+                </div>
+              )}
+            </div>
           )}
           <TranscriptViewer
             key={`${loadedVideoId ?? 'empty'}-${loadCount}`}
@@ -316,8 +352,9 @@ export default function EmbeddingLayoutView() {
             onWindowChange={handleWindowChange}
             onParamsBlur={handleParamsBlur}
             onCursorChange={handleCursorChange}
-            externalPosition={externalPosition}
-            externalPlaying={ytPlaying}
+            onAllowFasterChange={setAllowFaster}
+            externalPosition={allowFaster ? undefined : externalPosition}
+            externalPlaying={allowFaster ? undefined : ytPlaying}
             onScrub={handleScrub}
             onPlayingChange={setTranscriptPlaying}
             onSpeedChange={setPlaybackRate}

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import TranscriptViewer from './TranscriptViewer'
 import YoutubePlayerEmbed from './YoutubePlayerEmbed'
 import ScatterPlot3D from './ScatterPlot3D'
@@ -106,6 +106,30 @@ export default function EmbeddingLayoutView() {
 
   // Scatter highlight state
   const [highlightIndex, setHighlightIndex] = useState<number | null>(null)
+  const segmentsRef = useRef<string[] | null>(null)
+
+  // Keep ref in sync so cursor handler always sees latest segments
+  useEffect(() => { segmentsRef.current = segments }, [segments])
+
+  const handleCursorChange = useCallback((wordIndex: number) => {
+    const segs = segmentsRef.current
+    if (!segs || segs.length === 0) return
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    const words = text.trim().split(/\s+/).filter(Boolean)
+    if (words.length === 0) return
+    const step = Math.max(1, Math.round(windowSize * (1 - overlapPct / 100)))
+    const initialCursor = Math.min(windowSize - 1, words.length - 1)
+    let bestIdx = 0
+    let bestDist = Infinity
+    for (let i = 0; i < segs.length; i++) {
+      const cursor = Math.min(words.length - 1, initialCursor + i * step)
+      const windowStart = Math.max(0, cursor - windowSize + 1)
+      const endIdx = Math.min(words.length - 1, windowStart + windowSize - 1)
+      const dist = Math.abs(endIdx - wordIndex)
+      if (dist < bestDist) { bestDist = dist; bestIdx = i }
+    }
+    setHighlightIndex(bestIdx)
+  }, [])
 
   const handleLoad = async () => {
     const videoId = extractVideoId(urlInput)
@@ -277,6 +301,7 @@ export default function EmbeddingLayoutView() {
             initialDuration={loadedDuration ?? undefined}
             onWindowChange={handleWindowChange}
             onParamsBlur={handleParamsBlur}
+            onCursorChange={handleCursorChange}
             externalPosition={externalPosition}
             externalPlaying={ytPlaying}
             onScrub={handleScrub}

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -175,7 +175,18 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
     }
   }
 
+  const mouseDownRef = useRef<{ x: number; y: number } | null>(null)
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    mouseDownRef.current = { x: e.clientX, y: e.clientY }
+  }
+
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const down = mouseDownRef.current
+    if (!down) return
+    const dx = e.clientX - down.x
+    const dy = e.clientY - down.y
+    if (dx * dx + dy * dy > 25) return // >5px movement = drag, not click
     const s = sceneRef.current
     if (!s) return
     const rect = mountRef.current!.getBoundingClientRect()
@@ -189,7 +200,7 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
   }
 
   return (
-    <div className="scatter-wrap" ref={mountRef} onMouseMove={handleMouseMove} onClick={handleClick}>
+    <div className="scatter-wrap" ref={mountRef} onMouseMove={handleMouseMove} onMouseDown={handleMouseDown} onClick={handleClick}>
       {tooltip && (
         <div className="scatter-tooltip" style={{ left: tooltip.x + 12, top: tooltip.y + 12 }}>
           {tooltip.text}

--- a/src/SegmentsListModal.tsx
+++ b/src/SegmentsListModal.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import './SegmentProjectorModal.css'
+
+interface Props {
+  segments: string[]
+  onClose: () => void
+}
+
+export default function SegmentsListModal({ segments, onClose }: Props) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div className="projector-backdrop" onClick={e => { if (e.target === e.currentTarget) onClose() }}>
+      <div className="projector-panel">
+        <div className="projector-header">
+          <h2>Segments</h2>
+          <button className="projector-close" onClick={onClose}>✕</button>
+        </div>
+        <div className="projector-body">
+          <div className="projector-list-col">
+            <ul className="segment-list">
+              {segments.map((seg, i) => (
+                <li key={i} className="segment-item">
+                  <span className="segment-index">{i + 1}</span>
+                  <span className="segment-text">{seg}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/TranscriptViewer.css
+++ b/src/TranscriptViewer.css
@@ -153,6 +153,11 @@
   color: #fff;
 }
 
+.speed-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
 .word-count {
   font-size: 13px;
   color: var(--text);

--- a/src/TranscriptViewer.tsx
+++ b/src/TranscriptViewer.tsx
@@ -17,6 +17,7 @@ interface TranscriptViewerProps {
   onWindowChange?: (params: { windowSize: number; overlapPct: number; text: string }) => void
   onParamsBlur?: () => void
   onCursorChange?: (wordIndex: number) => void
+  onAllowFasterChange?: (allow: boolean) => void
   externalPosition?: number
   externalPlaying?: boolean
   onScrub?: (pos: number) => void
@@ -25,7 +26,7 @@ interface TranscriptViewerProps {
   maxSpeed?: number
 }
 
-export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, onCursorChange, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed }: TranscriptViewerProps = {}) {
+export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, onCursorChange, onAllowFasterChange, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed }: TranscriptViewerProps = {}) {
   const [text, setText] = useState(() => initialText ?? localStorage.getItem('transcript-text') ?? DEFAULT_TEXT)
   const [windowInput, setWindowInput] = useState('20')
   const [windowMode, setWindowMode] = useState<'words' | 'segments'>('words')
@@ -36,6 +37,7 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
   const [position, setPosition] = useState(0)
   const [isPlaying, setIsPlaying] = useState(false)
   const [autoScroll, setAutoScroll] = useState(true)
+  const [allowFaster, setAllowFaster] = useState(false)
 
   const rafRef = useRef<number | null>(null)
   const startTimeRef = useRef<number | null>(null)
@@ -262,10 +264,28 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
                 key={s}
                 className={`speed-btn${speed === s ? ' active' : ''}`}
                 onClick={() => { setSpeed(s); onSpeedChange?.(s) }}
-                disabled={maxSpeed !== undefined && s > maxSpeed}
-                title={maxSpeed !== undefined && s > maxSpeed ? `YouTube player is capped at ${maxSpeed}x` : undefined}
+                disabled={!allowFaster && maxSpeed !== undefined && s > maxSpeed}
+                title={!allowFaster && maxSpeed !== undefined && s > maxSpeed ? `YouTube player is capped at ${maxSpeed}x` : undefined}
               >{s}x</button>
             ))}
+            {maxSpeed !== undefined && (
+              <label className="radio-label">
+                <input
+                  type="checkbox"
+                  checked={allowFaster}
+                  onChange={e => {
+                    const checked = e.target.checked
+                    setAllowFaster(checked)
+                    if (!checked && speed > maxSpeed) {
+                      setSpeed(maxSpeed)
+                      onSpeedChange?.(maxSpeed)
+                    }
+                    onAllowFasterChange?.(checked)
+                  }}
+                />
+                allow faster
+              </label>
+            )}
           </div>
           <label className="radio-label" style={{ marginLeft: 'auto' }}>
             <input type="checkbox" checked={autoScroll} onChange={e => setAutoScroll(e.target.checked)} />

--- a/src/TranscriptViewer.tsx
+++ b/src/TranscriptViewer.tsx
@@ -28,16 +28,16 @@ interface TranscriptViewerProps {
 
 export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, onCursorChange, onAllowFasterChange, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed }: TranscriptViewerProps = {}) {
   const [text, setText] = useState(() => initialText ?? localStorage.getItem('transcript-text') ?? DEFAULT_TEXT)
-  const [windowInput, setWindowInput] = useState('20')
-  const [windowMode, setWindowMode] = useState<'words' | 'segments'>('words')
-  const [overlapInput, setOverlapInput] = useState('50')
+  const [windowInput, setWindowInput] = useState(() => localStorage.getItem('transcript-window') ?? '20')
+  const [windowMode, setWindowMode] = useState<'words' | 'segments'>(() => (localStorage.getItem('transcript-window-mode') as 'words' | 'segments') ?? 'words')
+  const [overlapInput, setOverlapInput] = useState(() => localStorage.getItem('transcript-overlap') ?? '50')
   const [durationInput, setDurationInput] = useState(() => initialDuration ?? localStorage.getItem('transcript-duration') ?? '30')
   const duration = Math.max(1, parseTimecode(durationInput) || 1)
   const [speed, setSpeed] = useState(1)
   const [position, setPosition] = useState(0)
   const [isPlaying, setIsPlaying] = useState(false)
-  const [autoScroll, setAutoScroll] = useState(true)
-  const [allowFaster, setAllowFaster] = useState(false)
+  const [autoScroll, setAutoScroll] = useState(() => localStorage.getItem('transcript-auto-scroll') !== 'false')
+  const [allowFaster, setAllowFaster] = useState(() => localStorage.getItem('transcript-allow-faster') === 'true')
 
   const rafRef = useRef<number | null>(null)
   const startTimeRef = useRef<number | null>(null)
@@ -210,16 +210,16 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
               min={1}
               className={windowInputNum <= 0 ? 'input-error' : ''}
               value={windowInput}
-              onChange={e => setWindowInput(e.target.value)}
+              onChange={e => { setWindowInput(e.target.value); localStorage.setItem('transcript-window', e.target.value) }}
               onBlur={onParamsBlur}
               style={{ width: 64 }}
             />
             <label className="radio-label">
-              <input type="radio" name="windowMode" value="words" checked={windowMode === 'words'} onChange={() => setWindowMode('words')} />
+              <input type="radio" name="windowMode" value="words" checked={windowMode === 'words'} onChange={() => { setWindowMode('words'); localStorage.setItem('transcript-window-mode', 'words') }} />
               words
             </label>
             <label className="radio-label">
-              <input type="radio" name="windowMode" value="segments" checked={windowMode === 'segments'} onChange={() => setWindowMode('segments')} />
+              <input type="radio" name="windowMode" value="segments" checked={windowMode === 'segments'} onChange={() => { setWindowMode('segments'); localStorage.setItem('transcript-window-mode', 'segments') }} />
               segments
             </label>
             {windowMode === 'segments' && windowInputNum > 0 && words.length > 0 && (
@@ -245,7 +245,7 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
               max={99}
               className={parseFloat(overlapInput) < 0 || parseFloat(overlapInput) >= 100 ? 'input-error' : ''}
               value={overlapInput}
-              onChange={e => setOverlapInput(e.target.value)}
+              onChange={e => { setOverlapInput(e.target.value); localStorage.setItem('transcript-overlap', e.target.value) }}
               onBlur={onParamsBlur}
               style={{ width: 52 }}
             />
@@ -276,6 +276,7 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
                   onChange={e => {
                     const checked = e.target.checked
                     setAllowFaster(checked)
+                    localStorage.setItem('transcript-allow-faster', String(checked))
                     if (!checked && speed > maxSpeed) {
                       setSpeed(maxSpeed)
                       onSpeedChange?.(maxSpeed)
@@ -288,7 +289,7 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
             )}
           </div>
           <label className="radio-label" style={{ marginLeft: 'auto' }}>
-            <input type="checkbox" checked={autoScroll} onChange={e => setAutoScroll(e.target.checked)} />
+            <input type="checkbox" checked={autoScroll} onChange={e => { setAutoScroll(e.target.checked); localStorage.setItem('transcript-auto-scroll', String(e.target.checked)) }} />
             auto-scroll
           </label>
           <span className="word-count">{words.length} words</span>

--- a/src/TranscriptViewer.tsx
+++ b/src/TranscriptViewer.tsx
@@ -15,6 +15,7 @@ interface TranscriptViewerProps {
   initialText?: string
   initialDuration?: string
   onWindowChange?: (params: { windowSize: number; overlapPct: number; text: string }) => void
+  onParamsBlur?: () => void
   externalPosition?: number
   externalPlaying?: boolean
   onScrub?: (pos: number) => void
@@ -23,7 +24,7 @@ interface TranscriptViewerProps {
   maxSpeed?: number
 }
 
-export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed }: TranscriptViewerProps = {}) {
+export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed }: TranscriptViewerProps = {}) {
   const [text, setText] = useState(() => initialText ?? localStorage.getItem('transcript-text') ?? DEFAULT_TEXT)
   const [windowInput, setWindowInput] = useState('20')
   const [windowMode, setWindowMode] = useState<'words' | 'segments'>('words')
@@ -180,6 +181,7 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
           className="paste-area"
           value={text}
           onChange={e => { setText(e.target.value); localStorage.setItem('transcript-text', e.target.value); setPosition(0); stopPlayback() }}
+          onBlur={onParamsBlur}
           onPaste={e => {
             e.preventDefault()
             const normalized = e.clipboardData.getData('text').replace(/\s+/g, ' ').trim()
@@ -200,6 +202,7 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
               className={windowInputNum <= 0 ? 'input-error' : ''}
               value={windowInput}
               onChange={e => setWindowInput(e.target.value)}
+              onBlur={onParamsBlur}
               style={{ width: 64 }}
             />
             <label className="radio-label">
@@ -234,6 +237,7 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
               className={parseFloat(overlapInput) < 0 || parseFloat(overlapInput) >= 100 ? 'input-error' : ''}
               value={overlapInput}
               onChange={e => setOverlapInput(e.target.value)}
+              onBlur={onParamsBlur}
               style={{ width: 52 }}
             />
             %

--- a/src/TranscriptViewer.tsx
+++ b/src/TranscriptViewer.tsx
@@ -16,6 +16,7 @@ interface TranscriptViewerProps {
   initialDuration?: string
   onWindowChange?: (params: { windowSize: number; overlapPct: number; text: string }) => void
   onParamsBlur?: () => void
+  onCursorChange?: (wordIndex: number) => void
   externalPosition?: number
   externalPlaying?: boolean
   onScrub?: (pos: number) => void
@@ -24,7 +25,7 @@ interface TranscriptViewerProps {
   maxSpeed?: number
 }
 
-export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed }: TranscriptViewerProps = {}) {
+export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, onCursorChange, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed }: TranscriptViewerProps = {}) {
   const [text, setText] = useState(() => initialText ?? localStorage.getItem('transcript-text') ?? DEFAULT_TEXT)
   const [windowInput, setWindowInput] = useState('20')
   const [windowMode, setWindowMode] = useState<'words' | 'segments'>('words')
@@ -173,6 +174,12 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
   // onWindowChange intentionally omitted — callers should stabilize with useCallback/useRef
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [windowSize, overlapPct, text])
+
+  useEffect(() => {
+    onCursorChange?.(cursorIndex)
+  // onCursorChange intentionally omitted
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cursorIndex])
 
   return (
     <div className="transcript-page">

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -66,6 +66,7 @@ export default function YoutubeEmbeddingProjector() {
   const [transcriptPlaying, setTranscriptPlaying] = useState(false)
   const [ytPlaying, setYtPlaying] = useState(false)
   const [playbackRate, setPlaybackRate] = useState(1)
+  const [allowFaster, setAllowFaster] = useState(false)
 
   // Track current window params from TranscriptViewer without re-renders
   const windowParamsRef = useRef<{ windowSize: number; overlapPct: number; text: string }>({
@@ -202,14 +203,25 @@ export default function YoutubeEmbeddingProjector() {
       </div>
 
       {loadedVideoId && totalSecs && (
-        <YoutubePlayerEmbed
-          videoId={loadedVideoId}
-          onTimeUpdate={setVideoTime}
-          seekTo={seekTarget}
-          playing={transcriptPlaying}
-          onPlayStateChange={setYtPlaying}
-          playbackRate={playbackRate}
-        />
+        <div style={{ position: 'relative' }}>
+          <div style={{ visibility: allowFaster ? 'hidden' : 'visible' }}>
+            <YoutubePlayerEmbed
+              videoId={loadedVideoId}
+              onTimeUpdate={setVideoTime}
+              seekTo={allowFaster ? undefined : seekTarget}
+              playing={allowFaster ? false : transcriptPlaying}
+              onPlayStateChange={allowFaster ? undefined : setYtPlaying}
+              playbackRate={playbackRate}
+            />
+          </div>
+          {allowFaster && (
+            <div className="yt-player-container" style={{ position: 'absolute', inset: 0, margin: 0 }}>
+              <div className="yt-player-aspect" style={{ background: 'var(--code-bg)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <span style={{ color: 'var(--text)', opacity: 0.4, fontSize: 13 }}>YouTube paused — allow faster enabled</span>
+              </div>
+            </div>
+          )}
+        </div>
       )}
       <TranscriptViewer
         key={`${loadedVideoId ?? 'empty'}-${loadCount}`}
@@ -222,6 +234,7 @@ export default function YoutubeEmbeddingProjector() {
         onPlayingChange={setTranscriptPlaying}
         onSpeedChange={setPlaybackRate}
         maxSpeed={loadedVideoId ? 2 : undefined}
+        onAllowFasterChange={setAllowFaster}
       />
 
       {modalSegments && (

--- a/src/YoutubePlayerEmbed.tsx
+++ b/src/YoutubePlayerEmbed.tsx
@@ -67,14 +67,20 @@ export default function YoutubePlayerEmbed({ videoId, onTimeUpdate, seekTo, play
         events: {
           onStateChange: (event: YT.OnStateChangeEvent) => {
             const isPlaying = event.data === window.YT.PlayerState.PLAYING
+            const isPaused = event.data === window.YT.PlayerState.PAUSED
             if (isPlaying) {
               startPoll(playerRef.current!)
-            } else {
+              onPlayStateChangeRef.current?.(true)
+            } else if (isPaused) {
               stopPoll()
               // Fire one update so seeks while paused still move the transcript cursor
               onTimeUpdateRef.current(playerRef.current!.getCurrentTime())
+              onPlayStateChangeRef.current?.(false)
+            } else {
+              // BUFFERING or other transient states — stop polling but don't
+              // signal pause so seeks don't interrupt transcript playback
+              stopPoll()
             }
-            onPlayStateChangeRef.current?.(isPlaying)
           },
         },
       })


### PR DESCRIPTION
## Summary

- New `#v4` view with side-by-side layout: YouTube player + transcript on the left, inline 3D embedding panel on the right
- Embedding panel progresses from placeholder → model/progress indicators → inline `ScatterPlot3D`
- Red dot in scatter plot tracks transcript cursor with smooth interpolation between segment nodes
- Clicking a scatter point seeks the video and transcript cursor (drag-to-orbit is distinguished from click)
- "Show Segments" modal always reflects current window/overlap params
- "Allow faster" checkbox pauses YouTube behind a placeholder and unlocks 5x/10x speeds; re-enabling seeks back to transcript position and clamps speed to 2x
- All form state (window, overlap, window mode, auto-scroll, allow-faster) persists via localStorage
- Scatter click seeks transcript cursor even without a YouTube video loaded
- Updated index page subtitle

## Test plan

- [ ] Navigate to `#v4`, verify placeholder shown before transcript load
- [ ] Load a YouTube URL — transcript appears, segments computed, right panel shows model dropdown + Run Embedding + Show Segments
- [ ] Click Show Segments — modal lists segments matching current window/overlap
- [ ] Change window or overlap, blur field — segments recompute
- [ ] Click Run Embedding — progress shown, then ScatterPlot3D appears inline
- [ ] Play video — red dot interpolates smoothly through scatter plot
- [ ] Click a scatter point — video and transcript cursor jump to that position, playback continues
- [ ] Drag to orbit — does not trigger a seek
- [ ] Check "allow faster" — player replaced by placeholder, 5x/10x enabled
- [ ] Uncheck "allow faster" — player reappears at transcript position, speed clamped to 2x
- [ ] Refresh page — window, overlap, auto-scroll, allow-faster all restored
- [ ] With no video loaded, embed static text, click scatter — transcript cursor jumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)