### PR TITLE
VTT/SRT support, YouTube sync fixes, and UX improvements

### DIFF
--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -330,14 +330,14 @@ export default function EmbeddingLayoutView() {
             placeholder="https://www.youtube.com/watch?v=..."
           />
           <button className="yt-action-btn" onClick={handleLoad} disabled={isProd || loadStatus === 'loading'}>
-            {loadStatus === 'loading' ? 'Loading…' : 'Load'}
+            {loadStatus === 'loading' ? 'Loading…' : 'Fetch Transcript'}
           </button>
         </div>
         {loadStatus === 'error' && <p className="youtube-error">{loadError}</p>}
         {isProd && (
           <p className="youtube-notice">
             {currentVideoId
-              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Get the transcript for this video ↗</a> then paste it into the text area below.</>
+              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Download the transcript for this video ↗</a> then paste or load it below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
               : <>Paste a YouTube URL above to get started.</>
             }
           </p>
@@ -348,11 +348,11 @@ export default function EmbeddingLayoutView() {
       <div className="embedding-layout-panels">
         {/* Left: video + transcript */}
         <div className="embedding-layout-left">
-          {loadedVideoId && totalSecs && (
+          {currentVideoId && (
             <div style={{ position: 'relative' }}>
               <div style={{ visibility: allowFaster ? 'hidden' : 'visible' }}>
                 <YoutubePlayerEmbed
-                  videoId={loadedVideoId}
+                  videoId={currentVideoId}
                   onTimeUpdate={setVideoTime}
                   seekTo={allowFaster ? undefined : seekTarget}
                   playing={allowFaster ? false : transcriptPlaying}

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -217,6 +217,7 @@ export default function EmbeddingLayoutView() {
       localStorage.setItem('yt-duration', duration)
       localStorage.setItem('yt-video-id', videoId)
       localStorage.setItem('yt-word-timestamps', JSON.stringify(wordTimestamps))
+      localStorage.setItem('transcript-raw-text', text)
       setLoadStatus('idle')
       // Reset embedding state when new transcript loaded
       setEmbedPhase({ status: 'idle' })

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -5,6 +5,7 @@ import ScatterPlot3D from './ScatterPlot3D'
 import SegmentsListModal from './SegmentsListModal'
 import { getEmbeddings, EMBEDDING_MODELS, type EmbeddingModelId } from './embedSegments'
 import { runUmap } from './runUmap'
+import { buildTranscriptData } from './subtitleParser'
 import './YoutubeTranscriptViewer.css'
 import './SegmentProjectorModal.css'
 import './EmbeddingLayoutView.css'
@@ -18,22 +19,6 @@ function extractVideoId(url: string): string | null {
   } catch {
     return /^[a-zA-Z0-9_-]{11}$/.test(url.trim()) ? url.trim() : null
   }
-}
-
-function buildTranscriptData(segments: Array<{ text: string; offset: number }>): {
-  text: string
-  wordTimestamps: number[]
-} {
-  const words: string[] = []
-  const timestamps: number[] = []
-  for (const seg of segments) {
-    const segWords = seg.text.trim().split(/\s+/).filter(Boolean)
-    for (const w of segWords) {
-      words.push(w)
-      timestamps.push(seg.offset)
-    }
-  }
-  return { text: words.join(' '), wordTimestamps: timestamps }
 }
 
 function computeChunks(text: string, windowSize: number, overlapPct: number): string[] {
@@ -88,6 +73,21 @@ export default function EmbeddingLayoutView() {
   const handleWindowChange = useCallback((params: { windowSize: number; overlapPct: number; text: string }) => {
     windowParamsRef.current = params
     setHasTranscriptText(!!params.text.trim())
+  }, [])
+
+  const handleSubtitleLoad = useCallback((result: { text: string; wordTimestamps: number[]; durationSecs: number }) => {
+    setLoadedText(result.text)
+    setLoadedDuration(String(result.durationSecs))
+    setWordTimestamps(result.wordTimestamps)
+    setLoadedVideoId(null)
+    setLoadCount(c => c + 1)
+    localStorage.setItem('yt-transcript', result.text)
+    localStorage.setItem('yt-duration', String(result.durationSecs))
+    localStorage.setItem('yt-word-timestamps', JSON.stringify(result.wordTimestamps))
+    localStorage.removeItem('yt-video-id')
+    setEmbedPhase({ status: 'idle' })
+    const { windowSize, overlapPct } = windowParamsRef.current
+    setSegments(computeChunks(result.text, windowSize, overlapPct))
   }, [])
 
   const handleParamsBlur = useCallback(() => {
@@ -382,6 +382,7 @@ export default function EmbeddingLayoutView() {
             onPlayingChange={setTranscriptPlaying}
             onSpeedChange={setPlaybackRate}
             maxSpeed={loadedVideoId ? 2 : undefined}
+            onSubtitleLoad={handleSubtitleLoad}
           />
         </div>
 

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -130,7 +130,7 @@ export default function EmbeddingLayoutView() {
             ? (wordIndex / windowParamsRef.current.text.trim().split(/\s+/).filter(Boolean).length) * totalSecs
             : 0)
       setVideoTime(seekTime)
-      setSeekTarget(seekTime)
+      if (seekTime > 0) setSeekTarget(seekTime)
     }
     allowFasterPrevRef.current = allowFaster
   }, [allowFaster])

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -44,7 +44,11 @@ type EmbedPhase =
 const isProd = import.meta.env.PROD
 
 export default function EmbeddingLayoutView() {
-  const [urlInput, setUrlInput] = useState(() => localStorage.getItem('yt-url') ?? '')
+  const [urlInput, setUrlInput] = useState(() => {
+    const qsVideoId = new URLSearchParams(window.location.search).get('videoId')
+    if (qsVideoId) return `https://www.youtube.com/watch?v=${qsVideoId}`
+    return localStorage.getItem('yt-url') ?? ''
+  })
   const [loadedText, setLoadedText] = useState<string | null>(() => localStorage.getItem('yt-transcript'))
   const [loadedDuration, setLoadedDuration] = useState<string | null>(() => localStorage.getItem('yt-duration'))
   const [loadedVideoId, setLoadedVideoId] = useState<string | null>(() =>

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -65,8 +65,8 @@ export default function EmbeddingLayoutView() {
 
   const [hasTranscriptText, setHasTranscriptText] = useState(() => !!(loadedText?.trim()))
   const windowParamsRef = useRef<{ windowSize: number; overlapPct: number; text: string }>({
-    windowSize: 20,
-    overlapPct: 50,
+    windowSize: 40,
+    overlapPct: 80,
     text: loadedText ?? '',
   })
 

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -329,15 +329,17 @@ export default function EmbeddingLayoutView() {
             onKeyDown={e => { if (e.key === 'Enter' && !isProd) handleLoad() }}
             placeholder="https://www.youtube.com/watch?v=..."
           />
-          <button className="yt-action-btn" onClick={handleLoad} disabled={isProd || loadStatus === 'loading'}>
-            {loadStatus === 'loading' ? 'Loading…' : 'Fetch Transcript'}
+          <button className="yt-action-btn"
+            onClick={isProd ? () => window.open(transcriptToolUrl, '_blank') : handleLoad}
+            disabled={isProd ? !currentVideoId : loadStatus === 'loading'}>
+            {!isProd && loadStatus === 'loading' ? 'Loading…' : `Fetch Transcript${isProd ? ' ↗' : ''}`}
           </button>
         </div>
         {loadStatus === 'error' && <p className="youtube-error">{loadError}</p>}
         {isProd && (
           <p className="youtube-notice">
             {currentVideoId
-              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Download the transcript for this video ↗</a> then paste or load it below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
+              ? <>Paste or load the downloaded transcript below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
               : <>Paste a YouTube URL above to get started.</>
             }
           </p>

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -378,7 +378,7 @@ export default function EmbeddingLayoutView() {
             onWindowChange={handleWindowChange}
             onParamsBlur={handleParamsBlur}
             onCursorChange={handleCursorChange}
-            onAllowFasterChange={setAllowFaster}
+            onAllowFasterChange={allow => { setAllowFaster(allow); if (!allow) { setYtPlaying(false); setTranscriptPlaying(false) } }}
             externalPosition={(allowFaster ? undefined : externalPosition) ?? clickSeekPosition}
             externalPlaying={allowFaster ? undefined : ytPlaying}
             onScrub={handleScrub}

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -384,7 +384,7 @@ export default function EmbeddingLayoutView() {
             onScrub={handleScrub}
             onPlayingChange={setTranscriptPlaying}
             onSpeedChange={setPlaybackRate}
-            maxSpeed={loadedVideoId ? 2 : undefined}
+            maxSpeed={currentVideoId ? 2 : undefined}
             onSubtitleLoad={handleSubtitleLoad}
           />
         </div>

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -350,7 +350,7 @@ export default function EmbeddingLayoutView() {
       <div className="embedding-layout-panels">
         {/* Left: video + transcript */}
         <div className="embedding-layout-left">
-          {currentVideoId && (
+          {currentVideoId ? (
             <div style={{ position: 'relative' }}>
               <div style={{ visibility: allowFaster ? 'hidden' : 'visible' }}>
                 <YoutubePlayerEmbed
@@ -369,6 +369,12 @@ export default function EmbeddingLayoutView() {
                   </div>
                 </div>
               )}
+            </div>
+          ) : (
+            <div className="yt-player-container">
+              <div className="yt-player-aspect" style={{ background: 'var(--code-bg)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <span style={{ color: 'var(--text)', opacity: 0.4, fontSize: 13 }}>Paste a YouTube URL above to load the player</span>
+              </div>
             </div>
           )}
           <TranscriptViewer

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -5,7 +5,7 @@ import ScatterPlot3D from './ScatterPlot3D'
 import SegmentsListModal from './SegmentsListModal'
 import { getEmbeddings, EMBEDDING_MODELS, type EmbeddingModelId } from './embedSegments'
 import { runUmap } from './runUmap'
-import { buildTranscriptData } from './subtitleParser'
+import { buildTranscriptData, segmentsToVtt } from './subtitleParser'
 import './YoutubeTranscriptViewer.css'
 import './SegmentProjectorModal.css'
 import './EmbeddingLayoutView.css'
@@ -217,7 +217,7 @@ export default function EmbeddingLayoutView() {
       localStorage.setItem('yt-duration', duration)
       localStorage.setItem('yt-video-id', videoId)
       localStorage.setItem('yt-word-timestamps', JSON.stringify(wordTimestamps))
-      localStorage.setItem('transcript-raw-text', text)
+      localStorage.setItem('transcript-raw-text', segmentsToVtt(data.segments))
       setLoadStatus('idle')
       // Reset embedding state when new transcript loaded
       setEmbedPhase({ status: 'idle' })

--- a/src/EmbeddingLayoutView.tsx
+++ b/src/EmbeddingLayoutView.tsx
@@ -363,7 +363,7 @@ export default function EmbeddingLayoutView() {
                 />
               </div>
               {allowFaster && (
-                <div className="yt-player-container" style={{ position: 'absolute', inset: 0, margin: 0 }}>
+                <div className="yt-player-container" style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, margin: '0 auto' }}>
                   <div className="yt-player-aspect" style={{ background: 'var(--code-bg)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     <span style={{ color: 'var(--text)', opacity: 0.4, fontSize: 13 }}>YouTube paused — allow faster enabled</span>
                   </div>

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -35,7 +35,7 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
     controls: OrbitControls
     scene: THREE.Scene
     pointsMesh: THREE.Points
-    highlightMesh: THREE.Points
+    highlightMesh: THREE.Mesh
     raycaster: THREE.Raycaster
     animId: number
   } | null>(null)
@@ -95,11 +95,10 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
     const lineMesh = new THREE.Line(lineGeo, lineMat)
     scene.add(lineMesh)
 
-    // Highlight mesh (single point)
-    const hlGeo = new THREE.BufferGeometry()
-    hlGeo.setAttribute('position', new THREE.BufferAttribute(new Float32Array(3), 3))
-    const hlMat = new THREE.PointsMaterial({ size: 0.12, sizeAttenuation: true, color: 0xff2222 })
-    const highlightMesh = new THREE.Points(hlGeo, hlMat)
+    // Highlight mesh (sphere so it stays visible at any zoom level)
+    const hlGeo = new THREE.SphereGeometry(0.04, 16, 16)
+    const hlMat = new THREE.MeshBasicMaterial({ color: 0xff2222 })
+    const highlightMesh = new THREE.Mesh(hlGeo, hlMat)
     highlightMesh.visible = false
     scene.add(highlightMesh)
 
@@ -148,9 +147,7 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
       const x = pa[0] + (pb[0] - pa[0]) * t
       const y = pa[1] + (pb[1] - pa[1]) * t
       const z = pa[2] + (pb[2] - pa[2]) * t
-      const posAttr = s.highlightMesh.geometry.getAttribute('position') as THREE.BufferAttribute
-      posAttr.setXYZ(0, x, y, z)
-      posAttr.needsUpdate = true
+      s.highlightMesh.position.set(x, y, z)
       s.highlightMesh.visible = true
     } else {
       s.highlightMesh.visible = false

--- a/src/TranscriptViewer.css
+++ b/src/TranscriptViewer.css
@@ -18,6 +18,29 @@
   gap: 8px;
 }
 
+.paste-area-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.load-file-btn {
+  flex-shrink: 0;
+  padding: 6px 12px;
+  background: var(--code-bg);
+  color: var(--text-h);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.15s;
+}
+
+.load-file-btn:hover {
+  opacity: 0.75;
+}
+
 .paste-area {
   width: 100%;
   box-sizing: border-box;

--- a/src/TranscriptViewer.tsx
+++ b/src/TranscriptViewer.tsx
@@ -113,7 +113,11 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
   useEffect(() => {
     if (externalPosition !== undefined) {
       setPosition(externalPosition)
-      // Reset RAF baseline so the internal loop doesn't fight the external time source
+      // Stop the internal RAF — the external time source (YouTube player) owns position now
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
       startPositionRef.current = externalPosition
       startTimeRef.current = null
     }

--- a/src/TranscriptViewer.tsx
+++ b/src/TranscriptViewer.tsx
@@ -29,6 +29,7 @@ interface TranscriptViewerProps {
 }
 
 export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, onCursorChange, onAllowFasterChange, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed, onSubtitleLoad }: TranscriptViewerProps = {}) {
+  const [rawText, setRawText] = useState(() => localStorage.getItem('transcript-raw-text') ?? initialText ?? DEFAULT_TEXT)
   const [text, setText] = useState(() => initialText ?? localStorage.getItem('transcript-text') ?? DEFAULT_TEXT)
   const [windowInput, setWindowInput] = useState(() => localStorage.getItem('transcript-window') ?? '20')
   const [windowMode, setWindowMode] = useState<'words' | 'segments'>(() => (localStorage.getItem('transcript-window-mode') as 'words' | 'segments') ?? 'words')
@@ -174,9 +175,11 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
     })
   }, [stopPlayback, windowSize, overlapPct, words.length, onScrub])
 
-  const applySubtitleResult = useCallback((parsed: SubtitleParseResult) => {
+  const applySubtitleResult = useCallback((raw: string, parsed: SubtitleParseResult) => {
+    setRawText(raw)
     setText(parsed.text)
     setDurationInput(String(parsed.durationSecs))
+    localStorage.setItem('transcript-raw-text', raw)
     localStorage.setItem('transcript-text', parsed.text)
     localStorage.setItem('transcript-duration', String(parsed.durationSecs))
     setPosition(0)
@@ -192,10 +195,12 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
       const raw = ev.target?.result as string
       const parsed = detectAndParseSubtitle(raw)
       if (parsed) {
-        applySubtitleResult(parsed)
+        applySubtitleResult(raw, parsed)
       } else {
         const normalized = raw.replace(/\s+/g, ' ').trim()
+        setRawText(raw)
         setText(normalized)
+        localStorage.setItem('transcript-raw-text', raw)
         localStorage.setItem('transcript-text', normalized)
         setPosition(0)
         stopPlayback()
@@ -224,18 +229,29 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
         <div className="paste-area-row">
           <textarea
             className="paste-area"
-            value={text}
-            onChange={e => { setText(e.target.value); localStorage.setItem('transcript-text', e.target.value); setPosition(0); stopPlayback() }}
+            value={rawText}
+            onChange={e => {
+              const raw = e.target.value
+              const normalized = raw.replace(/\s+/g, ' ').trim()
+              setRawText(raw)
+              setText(normalized)
+              localStorage.setItem('transcript-raw-text', raw)
+              localStorage.setItem('transcript-text', normalized)
+              setPosition(0)
+              stopPlayback()
+            }}
             onBlur={onParamsBlur}
             onPaste={e => {
               e.preventDefault()
               const raw = e.clipboardData.getData('text')
               const parsed = detectAndParseSubtitle(raw)
               if (parsed) {
-                applySubtitleResult(parsed)
+                applySubtitleResult(raw, parsed)
               } else {
                 const normalized = raw.replace(/\s+/g, ' ').trim()
+                setRawText(raw)
                 setText(normalized)
+                localStorage.setItem('transcript-raw-text', raw)
                 localStorage.setItem('transcript-text', normalized)
                 setPosition(0)
                 stopPlayback()

--- a/src/TranscriptViewer.tsx
+++ b/src/TranscriptViewer.tsx
@@ -31,9 +31,9 @@ interface TranscriptViewerProps {
 export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, onCursorChange, onAllowFasterChange, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed, onSubtitleLoad }: TranscriptViewerProps = {}) {
   const [rawText, setRawText] = useState(() => localStorage.getItem('transcript-raw-text') ?? initialText ?? DEFAULT_TEXT)
   const [text, setText] = useState(() => initialText ?? localStorage.getItem('transcript-text') ?? DEFAULT_TEXT)
-  const [windowInput, setWindowInput] = useState(() => localStorage.getItem('transcript-window') ?? '20')
+  const [windowInput, setWindowInput] = useState(() => localStorage.getItem('transcript-window') ?? '40')
   const [windowMode, setWindowMode] = useState<'words' | 'segments'>(() => (localStorage.getItem('transcript-window-mode') as 'words' | 'segments') ?? 'words')
-  const [overlapInput, setOverlapInput] = useState(() => localStorage.getItem('transcript-overlap') ?? '50')
+  const [overlapInput, setOverlapInput] = useState(() => localStorage.getItem('transcript-overlap') ?? '80')
   const [durationInput, setDurationInput] = useState(() => initialDuration ?? localStorage.getItem('transcript-duration') ?? '30')
   const duration = Math.max(1, parseTimecode(durationInput) || 1)
   const [speed, setSpeed] = useState(1)

--- a/src/TranscriptViewer.tsx
+++ b/src/TranscriptViewer.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { detectAndParseSubtitle, type SubtitleParseResult } from './subtitleParser'
 import './TranscriptViewer.css'
 
 const DEFAULT_TEXT = `The embedding window is a concept from transformer models where a fixed-size context window moves through a sequence of tokens. As the window slides forward, the model attends to a new set of words, creating a representation of that local context. This visualization lets you see how the window advances through your text over time, simulating the way a transformer might process a long document or video transcript in chunks. Try pasting your own text, adjusting the window size to match your model's context length, and setting a playback duration to match the length of your source video or audio. Watch how the highlighted region moves steadily from the beginning to the end of the transcript, pausing and resuming as you explore.`
@@ -24,9 +25,10 @@ interface TranscriptViewerProps {
   onPlayingChange?: (playing: boolean) => void
   onSpeedChange?: (speed: number) => void
   maxSpeed?: number
+  onSubtitleLoad?: (result: SubtitleParseResult) => void
 }
 
-export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, onCursorChange, onAllowFasterChange, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed }: TranscriptViewerProps = {}) {
+export default function TranscriptViewer({ initialText, initialDuration, onWindowChange, onParamsBlur, onCursorChange, onAllowFasterChange, externalPosition, externalPlaying, onScrub, onPlayingChange, onSpeedChange, maxSpeed, onSubtitleLoad }: TranscriptViewerProps = {}) {
   const [text, setText] = useState(() => initialText ?? localStorage.getItem('transcript-text') ?? DEFAULT_TEXT)
   const [windowInput, setWindowInput] = useState(() => localStorage.getItem('transcript-window') ?? '20')
   const [windowMode, setWindowMode] = useState<'words' | 'segments'>(() => (localStorage.getItem('transcript-window-mode') as 'words' | 'segments') ?? 'words')
@@ -44,6 +46,7 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
   const startPositionRef = useRef(0)
   const wordRefsMap = useRef<Map<number, HTMLSpanElement>>(new Map())
   const textAreaRef = useRef<HTMLDivElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const words = text.trim() ? text.trim().split(/\s+/) : []
   const overlapPct = Math.min(99, Math.max(0, parseFloat(overlapInput) || 0))
@@ -171,6 +174,38 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
     })
   }, [stopPlayback, windowSize, overlapPct, words.length, onScrub])
 
+  const applySubtitleResult = useCallback((parsed: SubtitleParseResult) => {
+    setText(parsed.text)
+    setDurationInput(String(parsed.durationSecs))
+    localStorage.setItem('transcript-text', parsed.text)
+    localStorage.setItem('transcript-duration', String(parsed.durationSecs))
+    setPosition(0)
+    stopPlayback()
+    onSubtitleLoad?.(parsed)
+  }, [stopPlayback, onSubtitleLoad])
+
+  const handleFileLoad = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = ev => {
+      const raw = ev.target?.result as string
+      const parsed = detectAndParseSubtitle(raw)
+      if (parsed) {
+        applySubtitleResult(parsed)
+      } else {
+        const normalized = raw.replace(/\s+/g, ' ').trim()
+        setText(normalized)
+        localStorage.setItem('transcript-text', normalized)
+        setPosition(0)
+        stopPlayback()
+      }
+    }
+    reader.readAsText(file)
+    // Reset so the same file can be re-selected
+    e.target.value = ''
+  }, [applySubtitleResult, stopPlayback])
+
   useEffect(() => {
     onWindowChange?.({ windowSize, overlapPct, text })
   // onWindowChange intentionally omitted — callers should stabilize with useCallback/useRef
@@ -186,22 +221,34 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
   return (
     <div className="transcript-page">
       <div className="controls-panel">
-        <textarea
-          className="paste-area"
-          value={text}
-          onChange={e => { setText(e.target.value); localStorage.setItem('transcript-text', e.target.value); setPosition(0); stopPlayback() }}
-          onBlur={onParamsBlur}
-          onPaste={e => {
-            e.preventDefault()
-            const normalized = e.clipboardData.getData('text').replace(/\s+/g, ' ').trim()
-            setText(normalized)
-            localStorage.setItem('transcript-text', normalized)
-            setPosition(0)
-            stopPlayback()
-          }}
-          placeholder="Paste transcript text here…"
-          rows={3}
-        />
+        <div className="paste-area-row">
+          <textarea
+            className="paste-area"
+            value={text}
+            onChange={e => { setText(e.target.value); localStorage.setItem('transcript-text', e.target.value); setPosition(0); stopPlayback() }}
+            onBlur={onParamsBlur}
+            onPaste={e => {
+              e.preventDefault()
+              const raw = e.clipboardData.getData('text')
+              const parsed = detectAndParseSubtitle(raw)
+              if (parsed) {
+                applySubtitleResult(parsed)
+              } else {
+                const normalized = raw.replace(/\s+/g, ' ').trim()
+                setText(normalized)
+                localStorage.setItem('transcript-text', normalized)
+                setPosition(0)
+                stopPlayback()
+              }
+            }}
+            placeholder="Paste transcript text or .vtt/.srt here…"
+            rows={3}
+          />
+          <button type="button" className="load-file-btn"
+            onClick={() => fileInputRef.current?.click()}>Load file</button>
+          <input ref={fileInputRef} type="file" accept=".vtt,.srt,text/vtt,text/plain"
+            style={{ display: 'none' }} onChange={handleFileLoad} />
+        </div>
         <div className="controls-row">
           <div className="controls-item">
             Window

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -33,7 +33,11 @@ function computeChunks(text: string, windowSize: number, overlapPct: number): st
 const isProd = import.meta.env.PROD
 
 export default function YoutubeEmbeddingProjector() {
-  const [urlInput, setUrlInput] = useState(() => localStorage.getItem('yt-url') ?? '')
+  const [urlInput, setUrlInput] = useState(() => {
+    const qsVideoId = new URLSearchParams(window.location.search).get('videoId')
+    if (qsVideoId) return `https://www.youtube.com/watch?v=${qsVideoId}`
+    return localStorage.getItem('yt-url') ?? ''
+  })
   const [loadedText, setLoadedText] = useState<string | null>(() => localStorage.getItem('yt-transcript'))
   const [loadedDuration, setLoadedDuration] = useState<string | null>(() => localStorage.getItem('yt-duration'))
   const [loadedVideoId, setLoadedVideoId] = useState<string | null>(() =>

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -181,7 +181,7 @@ export default function YoutubeEmbeddingProjector() {
             placeholder="https://www.youtube.com/watch?v=..."
           />
           <button className="yt-action-btn" onClick={handleLoad} disabled={isProd || status === 'loading'}>
-            {status === 'loading' ? 'Loading…' : 'Load'}
+            {status === 'loading' ? 'Loading…' : 'Fetch Transcript'}
           </button>
           {hasTranscriptText && (
             <button className="open-projector-btn" onClick={handleOpenProjector}>
@@ -193,18 +193,18 @@ export default function YoutubeEmbeddingProjector() {
         {isProd && (
           <p className="youtube-notice">
             {currentVideoId
-              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Get the transcript for this video ↗</a> then paste it into the text area below.</>
+              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Download the transcript for this video ↗</a> then paste or load it below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
               : <>Paste a YouTube URL above to get started.</>
             }
           </p>
         )}
       </div>
 
-      {loadedVideoId && totalSecs && (
+      {currentVideoId && (
         <div style={{ position: 'relative' }}>
           <div style={{ visibility: allowFaster ? 'hidden' : 'visible' }}>
             <YoutubePlayerEmbed
-              videoId={loadedVideoId}
+              videoId={currentVideoId}
               onTimeUpdate={setVideoTime}
               seekTo={allowFaster ? undefined : seekTarget}
               playing={allowFaster ? false : transcriptPlaying}

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -233,7 +233,7 @@ export default function YoutubeEmbeddingProjector() {
         onScrub={handleScrub}
         onPlayingChange={setTranscriptPlaying}
         onSpeedChange={setPlaybackRate}
-        maxSpeed={loadedVideoId ? 2 : undefined}
+        maxSpeed={currentVideoId ? 2 : undefined}
         onAllowFasterChange={setAllowFaster}
         onSubtitleLoad={handleSubtitleLoad}
       />

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -234,7 +234,7 @@ export default function YoutubeEmbeddingProjector() {
         onPlayingChange={setTranscriptPlaying}
         onSpeedChange={setPlaybackRate}
         maxSpeed={currentVideoId ? 2 : undefined}
-        onAllowFasterChange={setAllowFaster}
+        onAllowFasterChange={allow => { setAllowFaster(allow); if (!allow) { setYtPlaying(false); setTranscriptPlaying(false) } }}
         onSubtitleLoad={handleSubtitleLoad}
       />
 

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -180,8 +180,10 @@ export default function YoutubeEmbeddingProjector() {
             onKeyDown={e => { if (e.key === 'Enter' && !isProd) handleLoad() }}
             placeholder="https://www.youtube.com/watch?v=..."
           />
-          <button className="yt-action-btn" onClick={handleLoad} disabled={isProd || status === 'loading'}>
-            {status === 'loading' ? 'Loading…' : 'Fetch Transcript'}
+          <button className="yt-action-btn"
+            onClick={isProd ? () => window.open(transcriptToolUrl, '_blank') : handleLoad}
+            disabled={isProd ? !currentVideoId : status === 'loading'}>
+            {!isProd && status === 'loading' ? 'Loading…' : `Fetch Transcript${isProd ? ' ↗' : ''}`}
           </button>
           {hasTranscriptText && (
             <button className="open-projector-btn" onClick={handleOpenProjector}>
@@ -193,7 +195,7 @@ export default function YoutubeEmbeddingProjector() {
         {isProd && (
           <p className="youtube-notice">
             {currentVideoId
-              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Download the transcript for this video ↗</a> then paste or load it below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
+              ? <>Paste or load the downloaded transcript below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
               : <>Paste a YouTube URL above to get started.</>
             }
           </p>

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useCallback } from 'react'
 import TranscriptViewer from './TranscriptViewer'
 import YoutubePlayerEmbed from './YoutubePlayerEmbed'
 import SegmentProjectorModal from './SegmentProjectorModal'
-import { buildTranscriptData } from './subtitleParser'
+import { buildTranscriptData, segmentsToVtt } from './subtitleParser'
 import './YoutubeTranscriptViewer.css'
 import './YoutubeEmbeddingProjector.css'
 
@@ -92,7 +92,7 @@ export default function YoutubeEmbeddingProjector() {
       localStorage.setItem('yt-duration', duration)
       localStorage.setItem('yt-video-id', videoId)
       localStorage.setItem('yt-word-timestamps', JSON.stringify(wordTimestamps))
-      localStorage.setItem('transcript-raw-text', text)
+      localStorage.setItem('transcript-raw-text', segmentsToVtt(data.segments))
       setStatus('idle')
     } catch (e) {
       setStatus('error')

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -92,6 +92,7 @@ export default function YoutubeEmbeddingProjector() {
       localStorage.setItem('yt-duration', duration)
       localStorage.setItem('yt-video-id', videoId)
       localStorage.setItem('yt-word-timestamps', JSON.stringify(wordTimestamps))
+      localStorage.setItem('transcript-raw-text', text)
       setStatus('idle')
     } catch (e) {
       setStatus('error')

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -202,7 +202,7 @@ export default function YoutubeEmbeddingProjector() {
         )}
       </div>
 
-      {currentVideoId && (
+      {currentVideoId ? (
         <div style={{ position: 'relative' }}>
           <div style={{ visibility: allowFaster ? 'hidden' : 'visible' }}>
             <YoutubePlayerEmbed
@@ -221,6 +221,12 @@ export default function YoutubeEmbeddingProjector() {
               </div>
             </div>
           )}
+        </div>
+      ) : (
+        <div className="yt-player-container">
+          <div className="yt-player-aspect" style={{ background: 'var(--code-bg)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <span style={{ color: 'var(--text)', opacity: 0.4, fontSize: 13 }}>Paste a YouTube URL above to load the player</span>
+          </div>
         </div>
       )}
       <TranscriptViewer

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -55,8 +55,8 @@ export default function YoutubeEmbeddingProjector() {
 
   // Track current window params from TranscriptViewer without re-renders
   const windowParamsRef = useRef<{ windowSize: number; overlapPct: number; text: string }>({
-    windowSize: 20,
-    overlapPct: 50,
+    windowSize: 40,
+    overlapPct: 80,
     text: loadedText ?? '',
   })
 

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback } from 'react'
 import TranscriptViewer from './TranscriptViewer'
 import YoutubePlayerEmbed from './YoutubePlayerEmbed'
 import SegmentProjectorModal from './SegmentProjectorModal'
+import { buildTranscriptData } from './subtitleParser'
 import './YoutubeTranscriptViewer.css'
 import './YoutubeEmbeddingProjector.css'
 
@@ -14,22 +15,6 @@ function extractVideoId(url: string): string | null {
   } catch {
     return /^[a-zA-Z0-9_-]{11}$/.test(url.trim()) ? url.trim() : null
   }
-}
-
-function buildTranscriptData(segments: Array<{ text: string; offset: number }>): {
-  text: string
-  wordTimestamps: number[]
-} {
-  const words: string[] = []
-  const timestamps: number[] = []
-  for (const seg of segments) {
-    const segWords = seg.text.trim().split(/\s+/).filter(Boolean)
-    for (const w of segWords) {
-      words.push(w)
-      timestamps.push(seg.offset)
-    }
-  }
-  return { text: words.join(' '), wordTimestamps: timestamps }
 }
 
 function computeChunks(text: string, windowSize: number, overlapPct: number): string[] {
@@ -155,6 +140,18 @@ export default function YoutubeEmbeddingProjector() {
     ? `https://www.youtube-transcript.io/videos?id=${currentVideoId}`
     : 'https://www.youtube-transcript.io'
 
+  const handleSubtitleLoad = useCallback((result: { text: string; wordTimestamps: number[]; durationSecs: number }) => {
+    setLoadedText(result.text)
+    setLoadedDuration(String(result.durationSecs))
+    setWordTimestamps(result.wordTimestamps)
+    setLoadedVideoId(null)
+    setLoadCount(c => c + 1)
+    localStorage.setItem('yt-transcript', result.text)
+    localStorage.setItem('yt-duration', String(result.durationSecs))
+    localStorage.setItem('yt-word-timestamps', JSON.stringify(result.wordTimestamps))
+    localStorage.removeItem('yt-video-id')
+  }, [])
+
   const handleOpenProjector = () => {
     const { windowSize, overlapPct, text } = windowParamsRef.current
     const chunks = computeChunks(text, windowSize, overlapPct)
@@ -235,6 +232,7 @@ export default function YoutubeEmbeddingProjector() {
         onSpeedChange={setPlaybackRate}
         maxSpeed={loadedVideoId ? 2 : undefined}
         onAllowFasterChange={setAllowFaster}
+        onSubtitleLoad={handleSubtitleLoad}
       />
 
       {modalSegments && (

--- a/src/YoutubeEmbeddingProjector.tsx
+++ b/src/YoutubeEmbeddingProjector.tsx
@@ -215,7 +215,7 @@ export default function YoutubeEmbeddingProjector() {
             />
           </div>
           {allowFaster && (
-            <div className="yt-player-container" style={{ position: 'absolute', inset: 0, margin: 0 }}>
+            <div className="yt-player-container" style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, margin: '0 auto' }}>
               <div className="yt-player-aspect" style={{ background: 'var(--code-bg)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 <span style={{ color: 'var(--text)', opacity: 0.4, fontSize: 13 }}>YouTube paused — allow faster enabled</span>
               </div>

--- a/src/YoutubePlayerEmbed.tsx
+++ b/src/YoutubePlayerEmbed.tsx
@@ -61,20 +61,28 @@ export default function YoutubePlayerEmbed({ videoId, onTimeUpdate, seekTo, play
       containerRef.current.innerHTML = ''
       containerRef.current.appendChild(div)
 
-      playerRef.current = new window.YT.Player(div, {
+      // Don't assign playerRef.current here — the object returned by new YT.Player()
+      // is not fully initialized until onReady fires. Assigning it early means
+      // playVideo/pauseVideo don't exist yet, causing crashes in sibling effects.
+      new window.YT.Player(div, {
         videoId,
         playerVars: { rel: 0, modestbranding: 1 },
         events: {
+          onReady: (event: YT.PlayerEvent) => {
+            // Only expose the player once it's fully initialized
+            playerRef.current = event.target
+          },
           onStateChange: (event: YT.OnStateChangeEvent) => {
+            if (!playerRef.current) return  // guard against post-destroy async events
             const isPlaying = event.data === window.YT.PlayerState.PLAYING
             const isPaused = event.data === window.YT.PlayerState.PAUSED
             if (isPlaying) {
-              startPoll(playerRef.current!)
+              startPoll(playerRef.current)
               onPlayStateChangeRef.current?.(true)
             } else if (isPaused) {
               stopPoll()
               // Fire one update so seeks while paused still move the transcript cursor
-              onTimeUpdateRef.current(playerRef.current!.getCurrentTime())
+              onTimeUpdateRef.current(playerRef.current.getCurrentTime())
               onPlayStateChangeRef.current?.(false)
             } else {
               // BUFFERING or other transient states — stop polling but don't

--- a/src/YoutubeTranscriptViewer.tsx
+++ b/src/YoutubeTranscriptViewer.tsx
@@ -149,22 +149,22 @@ export default function YoutubeTranscriptViewer() {
             onClick={handleLoad}
             disabled={isProd || status === 'loading'}
           >
-            {status === 'loading' ? 'Loading…' : 'Load'}
+            {status === 'loading' ? 'Loading…' : 'Fetch Transcript'}
           </button>
         </div>
         {status === 'error' && <p className="youtube-error">{errorMessage}</p>}
         {isProd && (
           <p className="youtube-notice">
             {currentVideoId
-              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Get the transcript for this video ↗</a> then paste it into the text area below.</>
+              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Download the transcript for this video ↗</a> then paste or load it below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
               : <>Paste a YouTube URL above to get started.</>
             }
           </p>
         )}
       </div>
-      {loadedVideoId && totalSecs && (
+      {currentVideoId && (
         <YoutubePlayerEmbed
-          videoId={loadedVideoId}
+          videoId={currentVideoId}
           onTimeUpdate={setVideoTime}
           seekTo={seekTarget}
           playing={transcriptPlaying}

--- a/src/YoutubeTranscriptViewer.tsx
+++ b/src/YoutubeTranscriptViewer.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 import TranscriptViewer from './TranscriptViewer'
 import YoutubePlayerEmbed from './YoutubePlayerEmbed'
-import { buildTranscriptData } from './subtitleParser'
+import { buildTranscriptData, segmentsToVtt } from './subtitleParser'
 import './YoutubeTranscriptViewer.css'
 
 function extractVideoId(url: string): string | null {
@@ -62,7 +62,7 @@ export default function YoutubeTranscriptViewer() {
       localStorage.setItem('yt-duration', duration)
       localStorage.setItem('yt-video-id', videoId)
       localStorage.setItem('yt-word-timestamps', JSON.stringify(wordTimestamps))
-      localStorage.setItem('transcript-raw-text', text)
+      localStorage.setItem('transcript-raw-text', segmentsToVtt(data.segments))
       setStatus('idle')
     } catch (e) {
       setStatus('error')

--- a/src/YoutubeTranscriptViewer.tsx
+++ b/src/YoutubeTranscriptViewer.tsx
@@ -162,7 +162,7 @@ export default function YoutubeTranscriptViewer() {
           </p>
         )}
       </div>
-      {currentVideoId && (
+      {currentVideoId ? (
         <YoutubePlayerEmbed
           videoId={currentVideoId}
           onTimeUpdate={setVideoTime}
@@ -171,6 +171,12 @@ export default function YoutubeTranscriptViewer() {
           onPlayStateChange={setYtPlaying}
           playbackRate={playbackRate}
         />
+      ) : (
+        <div className="yt-player-container">
+          <div className="yt-player-aspect" style={{ background: 'var(--code-bg)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <span style={{ color: 'var(--text)', opacity: 0.4, fontSize: 13 }}>Paste a YouTube URL above to load the player</span>
+          </div>
+        </div>
       )}
       <TranscriptViewer
         key={`${loadedVideoId ?? 'empty'}-${loadCount}`}

--- a/src/YoutubeTranscriptViewer.tsx
+++ b/src/YoutubeTranscriptViewer.tsx
@@ -181,7 +181,7 @@ export default function YoutubeTranscriptViewer() {
         onScrub={handleScrub}
         onPlayingChange={setTranscriptPlaying}
         onSpeedChange={setPlaybackRate}
-        maxSpeed={loadedVideoId ? 2 : undefined}
+        maxSpeed={currentVideoId ? 2 : undefined}
         onSubtitleLoad={handleSubtitleLoad}
       />
     </div>

--- a/src/YoutubeTranscriptViewer.tsx
+++ b/src/YoutubeTranscriptViewer.tsx
@@ -62,6 +62,7 @@ export default function YoutubeTranscriptViewer() {
       localStorage.setItem('yt-duration', duration)
       localStorage.setItem('yt-video-id', videoId)
       localStorage.setItem('yt-word-timestamps', JSON.stringify(wordTimestamps))
+      localStorage.setItem('transcript-raw-text', text)
       setStatus('idle')
     } catch (e) {
       setStatus('error')

--- a/src/YoutubeTranscriptViewer.tsx
+++ b/src/YoutubeTranscriptViewer.tsx
@@ -18,7 +18,11 @@ function extractVideoId(url: string): string | null {
 const isProd = import.meta.env.PROD
 
 export default function YoutubeTranscriptViewer() {
-  const [urlInput, setUrlInput] = useState(() => localStorage.getItem('yt-url') ?? '')
+  const [urlInput, setUrlInput] = useState(() => {
+    const qsVideoId = new URLSearchParams(window.location.search).get('videoId')
+    if (qsVideoId) return `https://www.youtube.com/watch?v=${qsVideoId}`
+    return localStorage.getItem('yt-url') ?? ''
+  })
   const [loadedText, setLoadedText] = useState<string | null>(() => localStorage.getItem('yt-transcript'))
   const [loadedDuration, setLoadedDuration] = useState<string | null>(() => localStorage.getItem('yt-duration'))
   const [loadedVideoId, setLoadedVideoId] = useState<string | null>(() =>

--- a/src/YoutubeTranscriptViewer.tsx
+++ b/src/YoutubeTranscriptViewer.tsx
@@ -1,23 +1,8 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import TranscriptViewer from './TranscriptViewer'
 import YoutubePlayerEmbed from './YoutubePlayerEmbed'
+import { buildTranscriptData } from './subtitleParser'
 import './YoutubeTranscriptViewer.css'
-
-function buildTranscriptData(segments: Array<{ text: string; offset: number }>): {
-  text: string
-  wordTimestamps: number[]
-} {
-  const words: string[] = []
-  const timestamps: number[] = []
-  for (const seg of segments) {
-    const segWords = seg.text.trim().split(/\s+/).filter(Boolean)
-    for (const w of segWords) {
-      words.push(w)
-      timestamps.push(seg.offset)
-    }
-  }
-  return { text: words.join(' '), wordTimestamps: timestamps }
-}
 
 function extractVideoId(url: string): string | null {
   try {
@@ -83,6 +68,18 @@ export default function YoutubeTranscriptViewer() {
       setErrorMessage(String(e))
     }
   }
+
+  const handleSubtitleLoad = useCallback((result: { text: string; wordTimestamps: number[]; durationSecs: number }) => {
+    setLoadedText(result.text)
+    setLoadedDuration(String(result.durationSecs))
+    setWordTimestamps(result.wordTimestamps)
+    setLoadedVideoId(null)
+    setLoadCount(c => c + 1)
+    localStorage.setItem('yt-transcript', result.text)
+    localStorage.setItem('yt-duration', String(result.durationSecs))
+    localStorage.setItem('yt-word-timestamps', JSON.stringify(result.wordTimestamps))
+    localStorage.removeItem('yt-video-id')
+  }, [])
 
   const totalSecs = loadedDuration ? parseInt(loadedDuration) : null
   const externalPosition = (() => {
@@ -184,6 +181,7 @@ export default function YoutubeTranscriptViewer() {
         onPlayingChange={setTranscriptPlaying}
         onSpeedChange={setPlaybackRate}
         maxSpeed={loadedVideoId ? 2 : undefined}
+        onSubtitleLoad={handleSubtitleLoad}
       />
     </div>
   )

--- a/src/YoutubeTranscriptViewer.tsx
+++ b/src/YoutubeTranscriptViewer.tsx
@@ -146,17 +146,17 @@ export default function YoutubeTranscriptViewer() {
           />
           <button
             className="yt-action-btn"
-            onClick={handleLoad}
-            disabled={isProd || status === 'loading'}
+            onClick={isProd ? () => window.open(transcriptToolUrl, '_blank') : handleLoad}
+            disabled={isProd ? !currentVideoId : status === 'loading'}
           >
-            {status === 'loading' ? 'Loading…' : 'Fetch Transcript'}
+            {!isProd && status === 'loading' ? 'Loading…' : `Fetch Transcript${isProd ? ' ↗' : ''}`}
           </button>
         </div>
         {status === 'error' && <p className="youtube-error">{errorMessage}</p>}
         {isProd && (
           <p className="youtube-notice">
             {currentVideoId
-              ? <><a href={transcriptToolUrl} target="_blank" rel="noopener">Download the transcript for this video ↗</a> then paste or load it below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
+              ? <>Paste or load the downloaded transcript below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
               : <>Paste a YouTube URL above to get started.</>
             }
           </p>

--- a/src/subtitleParser.ts
+++ b/src/subtitleParser.ts
@@ -4,6 +4,29 @@ export interface SubtitleParseResult {
   durationSecs: number
 }
 
+function formatVttTime(ms: number): string {
+  const totalSecs = ms / 1000
+  const h = Math.floor(totalSecs / 3600)
+  const m = Math.floor((totalSecs % 3600) / 60)
+  const s = totalSecs % 60
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${s.toFixed(3).padStart(6, '0')}`
+}
+
+export function segmentsToVtt(segments: Array<{ text: string; offset: number; duration?: number }>): string {
+  const lines = ['WEBVTT', '']
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]
+    const start = seg.offset
+    const end = seg.duration != null
+      ? start + seg.duration
+      : (segments[i + 1]?.offset ?? start + 2000)
+    lines.push(`${formatVttTime(start)} --> ${formatVttTime(end)}`)
+    lines.push(seg.text.trim())
+    lines.push('')
+  }
+  return lines.join('\n')
+}
+
 export function buildTranscriptData(
   segments: Array<{ text: string; offset: number }>
 ): { text: string; wordTimestamps: number[] } {

--- a/src/subtitleParser.ts
+++ b/src/subtitleParser.ts
@@ -1,3 +1,8 @@
+function decodeHtmlEntities(str: string): string {
+  const doc = new DOMParser().parseFromString(str, 'text/html')
+  return doc.documentElement.textContent ?? str
+}
+
 export interface SubtitleParseResult {
   text: string
   wordTimestamps: number[]  // seconds, one per word
@@ -21,7 +26,7 @@ export function segmentsToVtt(segments: Array<{ text: string; offset: number; du
       ? start + seg.duration
       : (segments[i + 1]?.offset ?? start + 2000)
     lines.push(`${formatVttTime(start)} --> ${formatVttTime(end)}`)
-    lines.push(seg.text.trim())
+    lines.push(decodeHtmlEntities(seg.text.trim()))
     lines.push('')
   }
   return lines.join('\n')
@@ -33,7 +38,7 @@ export function buildTranscriptData(
   const words: string[] = []
   const timestamps: number[] = []
   for (const seg of segments) {
-    const segWords = seg.text.trim().split(/\s+/).filter(Boolean)
+    const segWords = decodeHtmlEntities(seg.text.trim()).split(/\s+/).filter(Boolean)
     for (const w of segWords) {
       words.push(w)
       timestamps.push(seg.offset)

--- a/src/subtitleParser.ts
+++ b/src/subtitleParser.ts
@@ -1,0 +1,111 @@
+export interface SubtitleParseResult {
+  text: string
+  wordTimestamps: number[]  // seconds, one per word
+  durationSecs: number
+}
+
+export function buildTranscriptData(
+  segments: Array<{ text: string; offset: number }>
+): { text: string; wordTimestamps: number[] } {
+  const words: string[] = []
+  const timestamps: number[] = []
+  for (const seg of segments) {
+    const segWords = seg.text.trim().split(/\s+/).filter(Boolean)
+    for (const w of segWords) {
+      words.push(w)
+      timestamps.push(seg.offset)
+    }
+  }
+  return { text: words.join(' '), wordTimestamps: timestamps }
+}
+
+interface Cue {
+  startMs: number
+  endMs: number
+  text: string
+}
+
+function parseTimestampMs(ts: string): number {
+  // Supports HH:MM:SS.mmm or MM:SS.mmm (VTT uses '.', SRT uses ',')
+  const normalized = ts.trim().replace(',', '.')
+  const parts = normalized.split(':').map(Number)
+  if (parts.length === 3) {
+    return Math.round((parts[0] * 3600 + parts[1] * 60 + parts[2]) * 1000)
+  }
+  if (parts.length === 2) {
+    return Math.round((parts[0] * 60 + parts[1]) * 1000)
+  }
+  return 0
+}
+
+function parseCues(raw: string): Cue[] {
+  const cues: Cue[] = []
+  // Split into blocks by blank lines
+  const blocks = raw.split(/\n\s*\n/)
+  for (const block of blocks) {
+    const lines = block.trim().split('\n').map(l => l.trim()).filter(Boolean)
+    if (lines.length < 2) continue
+    // Find the timestamp line (contains ' --> ')
+    let tsLineIdx = -1
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes(' --> ')) { tsLineIdx = i; break }
+    }
+    if (tsLineIdx === -1) continue
+    const tsParts = lines[tsLineIdx].split(' --> ')
+    if (tsParts.length < 2) continue
+    const startMs = parseTimestampMs(tsParts[0].trim())
+    // End timestamp may have extra metadata (VTT position info), take only first token
+    const endMs = parseTimestampMs(tsParts[1].trim().split(/\s/)[0])
+    // Text lines are after the timestamp line
+    const textLines = lines.slice(tsLineIdx + 1)
+    const text = textLines.join(' ').replace(/<[^>]+>/g, '').trim()
+    if (text) {
+      cues.push({ startMs, endMs, text })
+    }
+  }
+  return cues
+}
+
+function cuesIntoResult(cues: Cue[]): SubtitleParseResult | null {
+  if (cues.length === 0) return null
+  const words: string[] = []
+  const timestamps: number[] = []
+  for (const cue of cues) {
+    const cueWords = cue.text.split(/\s+/).filter(Boolean)
+    for (const w of cueWords) {
+      words.push(w)
+      timestamps.push(cue.startMs / 1000)
+    }
+  }
+  if (words.length === 0) return null
+  const durationSecs = Math.ceil(Math.max(...cues.map(c => c.endMs)) / 1000)
+  return { text: words.join(' '), wordTimestamps: timestamps, durationSecs }
+}
+
+export function parseSubtitleFile(raw: string): SubtitleParseResult | null {
+  try {
+    const cues = parseCues(raw)
+    return cuesIntoResult(cues)
+  } catch {
+    return null
+  }
+}
+
+export function detectAndParseSubtitle(raw: string): SubtitleParseResult | null {
+  const lines = raw.split('\n').map(l => l.trim()).filter(Boolean)
+  if (lines.length < 2) return null
+
+  const firstLine = lines[0].replace(/^\uFEFF/, '')
+
+  // VTT detection
+  if (firstLine.startsWith('WEBVTT')) {
+    return parseSubtitleFile(raw)
+  }
+
+  // SRT detection: first non-blank line is a number, second contains ' --> '
+  if (/^\d+$/.test(firstLine) && lines[1].includes(' --> ')) {
+    return parseSubtitleFile(raw)
+  }
+
+  return null
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
             return
           }
           try {
-            const segments = await YoutubeTranscript.fetchTranscript(videoId)
+            let segments = await YoutubeTranscript.fetchTranscript(videoId, { lang: 'en' }).catch(
+              () => YoutubeTranscript.fetchTranscript(videoId)
+            )
             const last = segments[segments.length - 1]
             const totalDuration = last ? last.offset + last.duration : 0
             res.writeHead(200, { 'Content-Type': 'application/json' })


### PR DESCRIPTION
## Summary

- Add VTT/SRT subtitle paste and file load support
- Show YouTube player placeholder when no URL is present; improve static-mode UI
- Fix transcript textarea showing processed text instead of raw VTT/SRT after paste
- Prefer English transcript from YouTube API, fall back to first available track
- Decode HTML entities (e.g. `&#39;`) in YouTube transcript segments
- Fix word cursor racing ahead during slow speech then snapping back — stop internal RAF when YouTube player is driving position
- Fix red dot disappearing when zooming into 3D scatter plot (replace `Points` with `SphereGeometry`)
- Default window to 40 words and overlap to 80%
- Auto-populate YouTube URL field from `?videoId=` query parameter (all views)

## Test plan

- [ ] Paste a VTT or SRT transcript and confirm timing and text are correct
- [ ] Load a VTT/SRT file via the "Load file" button
- [ ] Fetch a YouTube transcript in dev and confirm no HTML entities appear
- [ ] Play a YouTube video and confirm the word cursor tracks speech without racing ahead
- [ ] Zoom into the 3D scatter plot and confirm the red dot stays visible
- [ ] Navigate to `/?videoId=Nj-hdQMa3uA#v2` (and `#v3`, `#v4`) and confirm the URL field is pre-populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)