### PR TITLE
v5: Cividis tube, shader glow renderer, 3-state camera follow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import TranscriptViewer from './TranscriptViewer'
 import YoutubeTranscriptViewer from './YoutubeTranscriptViewer'
 import YoutubeEmbeddingProjector from './YoutubeEmbeddingProjector'
 import EmbeddingLayoutView from './EmbeddingLayoutView'
+import EmbeddingLayoutViewV5 from './EmbeddingLayoutViewV5'
 import './App.css'
 
 function useHash() {
@@ -46,6 +47,12 @@ function IndexPage() {
             <a href="#v4">
               <strong>Embedding Layout</strong>
               <span>Side-by-side view: YouTube player and transcript with an inline 3D embedding panel.</span>
+            </a>
+          </li>
+          <li>
+            <a href="#v5">
+              <strong>Embedding Layout (Cividis)</strong>
+              <span>Same as v4, with a curved tube path colored by the Cividis scale.</span>
             </a>
           </li>
         </ul>
@@ -98,6 +105,7 @@ function App() {
   if (hash === '#v2') return <><GitHubCorner /><YoutubeTranscriptViewer /></>
   if (hash === '#v3') return <><GitHubCorner /><YoutubeEmbeddingProjector /></>
   if (hash === '#v4') return <><GitHubCorner /><EmbeddingLayoutView /></>
+  if (hash === '#v5') return <><GitHubCorner /><EmbeddingLayoutViewV5 /></>
   return <><GitHubCorner /><IndexPage /></>
 }
 

--- a/src/EmbeddingLayoutViewV5.tsx
+++ b/src/EmbeddingLayoutViewV5.tsx
@@ -1,0 +1,540 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import TranscriptViewer from './TranscriptViewer'
+import YoutubePlayerEmbed from './YoutubePlayerEmbed'
+import ScatterPlot3DV5 from './ScatterPlot3DV5'
+import SegmentsListModal from './SegmentsListModal'
+import { getEmbeddings, EMBEDDING_MODELS, type EmbeddingModelId } from './embedSegments'
+import { runUmap } from './runUmap'
+import { buildTranscriptData, segmentsToVtt } from './subtitleParser'
+import './YoutubeTranscriptViewer.css'
+import './SegmentProjectorModal.css'
+import './EmbeddingLayoutView.css'
+
+function extractVideoId(url: string): string | null {
+  try {
+    const u = new URL(url.trim())
+    if (u.hostname === 'youtu.be') return u.pathname.slice(1)
+    if (u.hostname.includes('youtube.com')) return u.searchParams.get('v')
+    return null
+  } catch {
+    return /^[a-zA-Z0-9_-]{11}$/.test(url.trim()) ? url.trim() : null
+  }
+}
+
+function computeChunks(text: string, windowSize: number, overlapPct: number): string[] {
+  const words = text.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return []
+  const step = Math.max(1, Math.round(windowSize * (1 - overlapPct / 100)))
+  const chunks: string[] = []
+  for (let cursor = Math.min(windowSize - 1, words.length - 1); cursor < words.length; cursor += step) {
+    const windowStart = Math.max(0, cursor - windowSize + 1)
+    chunks.push(words.slice(windowStart, windowStart + windowSize).join(' '))
+  }
+  return chunks
+}
+
+type EmbedPhase =
+  | { status: 'idle' }
+  | { status: 'model-loading'; progress: number }
+  | { status: 'embedding'; loaded: number; total: number }
+  | { status: 'umap-running' }
+  | { status: 'done'; points: [number, number, number][] }
+  | { status: 'error'; message: string }
+
+const isProd = import.meta.env.PROD
+
+export default function EmbeddingLayoutViewV5() {
+  const [urlInput, setUrlInput] = useState(() => {
+    const qsVideoId = new URLSearchParams(window.location.search).get('videoId')
+    if (qsVideoId) return `https://www.youtube.com/watch?v=${qsVideoId}`
+    return localStorage.getItem('yt-url') ?? ''
+  })
+  const [loadedText, setLoadedText] = useState<string | null>(() => localStorage.getItem('yt-transcript'))
+  const [loadedDuration, setLoadedDuration] = useState<string | null>(() => localStorage.getItem('yt-duration'))
+  const [loadedVideoId, setLoadedVideoId] = useState<string | null>(() =>
+    extractVideoId(localStorage.getItem('yt-url') ?? '') ? localStorage.getItem('yt-video-id') : null
+  )
+  const [loadCount, setLoadCount] = useState(0)
+  const [loadStatus, setLoadStatus] = useState<'idle' | 'loading' | 'error'>('idle')
+  const [loadError, setLoadError] = useState('')
+  const [wordTimestamps, setWordTimestamps] = useState<number[] | null>(
+    () => JSON.parse(localStorage.getItem('yt-word-timestamps') ?? 'null')
+  )
+  const [videoTime, setVideoTime] = useState(0)
+  const [seekTarget, setSeekTarget] = useState<number | undefined>(undefined)
+  const [transcriptPlaying, setTranscriptPlaying] = useState(false)
+  const [ytPlaying, setYtPlaying] = useState(false)
+  const [playbackRate, setPlaybackRate] = useState(1)
+  const [allowFaster, setAllowFaster] = useState(false)
+
+  const [hasTranscriptText, setHasTranscriptText] = useState(() => !!(loadedText?.trim()))
+  const windowParamsRef = useRef<{ windowSize: number; overlapPct: number; text: string }>({
+    windowSize: 40,
+    overlapPct: 80,
+    text: loadedText ?? '',
+  })
+
+  const handleWindowChange = useCallback((params: { windowSize: number; overlapPct: number; text: string }) => {
+    windowParamsRef.current = params
+    setHasTranscriptText(!!params.text.trim())
+  }, [])
+
+  const handleSubtitleLoad = useCallback((result: { text: string; wordTimestamps: number[]; durationSecs: number }) => {
+    setLoadedText(result.text)
+    setLoadedDuration(String(result.durationSecs))
+    setWordTimestamps(result.wordTimestamps)
+    setLoadedVideoId(null)
+    setLoadCount(c => c + 1)
+    localStorage.setItem('yt-transcript', result.text)
+    localStorage.setItem('yt-duration', String(result.durationSecs))
+    localStorage.setItem('yt-word-timestamps', JSON.stringify(result.wordTimestamps))
+    localStorage.removeItem('yt-video-id')
+    setEmbedPhase({ status: 'idle' })
+    const { windowSize, overlapPct } = windowParamsRef.current
+    setSegments(computeChunks(result.text, windowSize, overlapPct))
+  }, [])
+
+  const handleParamsBlur = useCallback(() => {
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    if (!text.trim()) return
+    setSegments(computeChunks(text, windowSize, overlapPct))
+  }, [])
+
+  // Embedding state
+  const [selectedModel, setSelectedModel] = useState<EmbeddingModelId>(() => {
+    const stored = localStorage.getItem('projector-model')
+    return (EMBEDDING_MODELS.find(m => m.id === stored) ?? EMBEDDING_MODELS.find(m => m.default)!).id
+  })
+  const [embedPhase, setEmbedPhase] = useState<EmbedPhase>({ status: 'idle' })
+  const [segments, setSegments] = useState<string[] | null>(null)
+  const [showSegmentsModal, setShowSegmentsModal] = useState(false)
+
+  // Scatter highlight state
+  const [highlightIndex, setHighlightIndex] = useState<number | null>(null)
+  const [clickSeekPosition, setClickSeekPosition] = useState<number | undefined>(undefined)
+  const segmentsRef = useRef<string[] | null>(null)
+  const currentWordIndexRef = useRef(0)
+  const wordTimestampsRef = useRef(wordTimestamps)
+  useEffect(() => { wordTimestampsRef.current = wordTimestamps }, [wordTimestamps])
+  const totalSecsRef = useRef<number | null>(null)
+
+  // Keep ref in sync so cursor handler always sees latest segments
+  useEffect(() => { segmentsRef.current = segments }, [segments])
+
+  // When re-enabling YouTube player, seek it to where the transcript cursor ended up
+  const allowFasterPrevRef = useRef(false)
+  useEffect(() => {
+    if (!allowFaster && allowFasterPrevRef.current && totalSecsRef.current) {
+      const totalSecs = totalSecsRef.current
+      const wordIndex = currentWordIndexRef.current
+      const ts = wordTimestampsRef.current
+      const seekTime = ts && ts.length > 0
+        ? ts[Math.min(wordIndex, ts.length - 1)]
+        : (windowParamsRef.current.text.trim().split(/\s+/).filter(Boolean).length > 0
+            ? (wordIndex / windowParamsRef.current.text.trim().split(/\s+/).filter(Boolean).length) * totalSecs
+            : 0)
+      setVideoTime(seekTime)
+      if (seekTime > 0) setSeekTarget(seekTime)
+    }
+    allowFasterPrevRef.current = allowFaster
+  }, [allowFaster])
+
+  const handleCursorChange = useCallback((wordIndex: number) => {
+    currentWordIndexRef.current = wordIndex
+    const segs = segmentsRef.current
+    if (!segs || segs.length === 0) return
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    const words = text.trim().split(/\s+/).filter(Boolean)
+    if (words.length === 0) return
+    const step = Math.max(1, Math.round(windowSize * (1 - overlapPct / 100)))
+    const initialCursor = Math.min(windowSize - 1, words.length - 1)
+
+    // Compute end word index for each segment
+    const endIndices = segs.map((_, i) => {
+      const cursor = Math.min(words.length - 1, initialCursor + i * step)
+      const windowStart = Math.max(0, cursor - windowSize + 1)
+      return Math.min(words.length - 1, windowStart + windowSize - 1)
+    })
+
+    // Interpolate: find the two adjacent segments whose ends bracket wordIndex
+    if (wordIndex <= endIndices[0]) {
+      setHighlightIndex(0)
+      return
+    }
+    if (wordIndex >= endIndices[endIndices.length - 1]) {
+      setHighlightIndex(segs.length - 1)
+      return
+    }
+    for (let i = 0; i < endIndices.length - 1; i++) {
+      if (wordIndex >= endIndices[i] && wordIndex < endIndices[i + 1]) {
+        const t = (wordIndex - endIndices[i]) / (endIndices[i + 1] - endIndices[i])
+        setHighlightIndex(i + t)
+        return
+      }
+    }
+  }, [])
+
+  const handlePointClick = useCallback((idx: number) => {
+    setHighlightIndex(idx)
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    const words = text.trim().split(/\s+/).filter(Boolean)
+    if (words.length === 0) return
+    const step = Math.max(1, Math.round(windowSize * (1 - overlapPct / 100)))
+    const initialCursor = Math.min(windowSize - 1, words.length - 1)
+    const wordIndex = Math.min(words.length - 1, initialCursor + idx * step)
+    // Always set a direct word-index position so the transcript cursor jumps
+    // even when no video is loaded (externalPosition would otherwise be undefined)
+    setClickSeekPosition(words.length > 1 ? wordIndex / (words.length - 1) : 0)
+    // Also seek the video if available
+    const secs = totalSecsRef.current
+    if (!secs) return
+    const ts = wordTimestampsRef.current
+    const seekTime = ts && ts.length > 0
+      ? ts[Math.min(wordIndex, ts.length - 1)]
+      : (words.length > 1 ? (wordIndex / (words.length - 1)) * secs : 0)
+    setVideoTime(seekTime)
+    setSeekTarget(seekTime)
+  }, [])
+
+  const handleLoad = async () => {
+    const videoId = extractVideoId(urlInput)
+    if (!videoId) {
+      setLoadStatus('error')
+      setLoadError('Could not extract a video ID from the input.')
+      return
+    }
+    setLoadStatus('loading')
+    setLoadError('')
+    try {
+      const res = await fetch(`/api/transcript?videoId=${encodeURIComponent(videoId)}`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`)
+      const { text, wordTimestamps } = buildTranscriptData(data.segments)
+      const duration = String(Math.round(data.totalDuration))
+      setLoadedText(text)
+      setLoadedDuration(duration)
+      setLoadedVideoId(videoId)
+      setWordTimestamps(wordTimestamps)
+      setLoadCount(c => c + 1)
+      localStorage.setItem('yt-url', urlInput)
+      localStorage.setItem('yt-transcript', text)
+      localStorage.setItem('yt-duration', duration)
+      localStorage.setItem('yt-video-id', videoId)
+      localStorage.setItem('yt-word-timestamps', JSON.stringify(wordTimestamps))
+      localStorage.setItem('transcript-raw-text', segmentsToVtt(data.segments))
+      setLoadStatus('idle')
+      // Reset embedding state when new transcript loaded
+      setEmbedPhase({ status: 'idle' })
+      const { windowSize, overlapPct } = windowParamsRef.current
+      setSegments(computeChunks(text, windowSize, overlapPct))
+    } catch (e) {
+      setLoadStatus('error')
+      setLoadError(String(e))
+    }
+  }
+
+  const totalSecs = loadedDuration ? parseInt(loadedDuration) : null
+  totalSecsRef.current = totalSecs
+
+  const externalPosition = (() => {
+    if (!totalSecs) return undefined
+    if (wordTimestamps && wordTimestamps.length > 1) {
+      if (videoTime < wordTimestamps[0]) return 0
+      let segFirstIdx = 0
+      for (let i = 1; i < wordTimestamps.length; i++) {
+        if (wordTimestamps[i] > videoTime) break
+        if (wordTimestamps[i] > wordTimestamps[i - 1]) segFirstIdx = i
+      }
+      let segLastIdx = segFirstIdx
+      while (segLastIdx + 1 < wordTimestamps.length && wordTimestamps[segLastIdx + 1] === wordTimestamps[segFirstIdx]) {
+        segLastIdx++
+      }
+      const segStart = wordTimestamps[segFirstIdx]
+      const nextSegStart = segLastIdx + 1 < wordTimestamps.length ? wordTimestamps[segLastIdx + 1] : totalSecs
+      const segDuration = nextSegStart - segStart
+      const segWordCount = segLastIdx - segFirstIdx + 1
+      const wordOffset = segDuration > 0
+        ? Math.min(Math.floor(((videoTime - segStart) / segDuration) * segWordCount), segWordCount - 1)
+        : 0
+      return (segFirstIdx + wordOffset) / (wordTimestamps.length - 1)
+    }
+    return videoTime / totalSecs
+  })()
+
+  const handleScrub = useCallback((pos: number) => {
+    if (!totalSecs) return
+    const t = pos * totalSecs
+    setVideoTime(t)
+    setSeekTarget(t)
+  }, [totalSecs])
+
+  const runEmbeddingOnChunks = async (chunks: string[]) => {
+    if (chunks.length === 0) return
+    setEmbedPhase({ status: 'model-loading', progress: 0 })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    try {
+      const vectors = await getEmbeddings(chunks, (loaded, total, phaseLabel) => {
+        if (phaseLabel === 'model-loading') {
+          setEmbedPhase({ status: 'model-loading', progress: loaded })
+        } else {
+          setEmbedPhase({ status: 'embedding', loaded, total })
+        }
+      }, selectedModel)
+      setEmbedPhase({ status: 'umap-running' })
+      await new Promise(resolve => setTimeout(resolve, 0))
+      const points = runUmap(vectors)
+      setEmbedPhase({ status: 'done', points })
+    } catch (e) {
+      setEmbedPhase({ status: 'error', message: String(e) })
+    }
+  }
+
+  const handleRunEmbedding = () => {
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    const chunks = computeChunks(text, windowSize, overlapPct)
+    setSegments(chunks)
+    runEmbeddingOnChunks(chunks)
+  }
+
+  const handleShowSegments = () => {
+    const { windowSize, overlapPct, text } = windowParamsRef.current
+    const chunks = computeChunks(text, windowSize, overlapPct)
+    setSegments(chunks)
+    setShowSegmentsModal(true)
+  }
+
+  const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status === 'embedding' || embedPhase.status === 'umap-running'
+  const isDone = embedPhase.status === 'done'
+
+  const currentVideoId = extractVideoId(urlInput)
+  const transcriptToolUrl = currentVideoId
+    ? `https://www.youtube-transcript.io/videos?id=${currentVideoId}`
+    : 'https://www.youtube-transcript.io'
+
+  return (
+    <div className="embedding-layout-wrapper">
+      {/* URL Bar */}
+      <div className="embedding-layout-bar">
+        <div className="embedding-layout-row">
+          <input
+            type="url"
+            className="youtube-url-input"
+            value={urlInput}
+            onChange={e => {
+              const val = e.target.value
+              setUrlInput(val)
+              localStorage.setItem('yt-url', val)
+              if (!extractVideoId(val)) {
+                setLoadedVideoId(null)
+                setWordTimestamps(null)
+                localStorage.removeItem('yt-word-timestamps')
+              }
+            }}
+            onKeyDown={e => { if (e.key === 'Enter' && !isProd) handleLoad() }}
+            placeholder="https://www.youtube.com/watch?v=..."
+          />
+          <button className="yt-action-btn"
+            onClick={isProd ? () => window.open(transcriptToolUrl, '_blank') : handleLoad}
+            disabled={isProd ? !currentVideoId : loadStatus === 'loading'}>
+            {!isProd && loadStatus === 'loading' ? 'Loading…' : `Fetch Transcript${isProd ? ' ↗' : ''}`}
+          </button>
+        </div>
+        {loadStatus === 'error' && <p className="youtube-error">{loadError}</p>}
+        {isProd && (
+          <p className="youtube-notice">
+            {currentVideoId
+              ? <>Paste or load the downloaded transcript below. VTT or SRT preferred — copied plaintext lacks timing and will degrade the experience.</>
+              : <>Paste a YouTube URL above to get started.</>
+            }
+          </p>
+        )}
+      </div>
+
+      {/* Main panels */}
+      <div className="embedding-layout-panels">
+        {/* Left: video + transcript */}
+        <div className="embedding-layout-left">
+          {currentVideoId ? (
+            <div style={{ position: 'relative' }}>
+              <div style={{ visibility: allowFaster ? 'hidden' : 'visible' }}>
+                <YoutubePlayerEmbed
+                  videoId={currentVideoId}
+                  onTimeUpdate={setVideoTime}
+                  seekTo={allowFaster ? undefined : seekTarget}
+                  playing={allowFaster ? false : transcriptPlaying}
+                  onPlayStateChange={allowFaster ? undefined : setYtPlaying}
+                  playbackRate={playbackRate}
+                />
+              </div>
+              {allowFaster && (
+                <div className="yt-player-container" style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0, margin: '0 auto' }}>
+                  <div className="yt-player-aspect" style={{ background: 'var(--code-bg)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <span style={{ color: 'var(--text)', opacity: 0.4, fontSize: 13 }}>YouTube paused — allow faster enabled</span>
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="yt-player-container">
+              <div className="yt-player-aspect" style={{ background: 'var(--code-bg)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <span style={{ color: 'var(--text)', opacity: 0.4, fontSize: 13 }}>Paste a YouTube URL above to load the player</span>
+              </div>
+            </div>
+          )}
+          <TranscriptViewer
+            key={`${loadedVideoId ?? 'empty'}-${loadCount}`}
+            initialText={loadedText ?? undefined}
+            initialDuration={loadedDuration ?? undefined}
+            onWindowChange={handleWindowChange}
+            onParamsBlur={handleParamsBlur}
+            onCursorChange={handleCursorChange}
+            onAllowFasterChange={allow => { setAllowFaster(allow); if (!allow) { setYtPlaying(false); setTranscriptPlaying(false) } }}
+            externalPosition={(allowFaster ? undefined : externalPosition) ?? clickSeekPosition}
+            externalPlaying={allowFaster ? undefined : ytPlaying}
+            onScrub={handleScrub}
+            onPlayingChange={setTranscriptPlaying}
+            onSpeedChange={setPlaybackRate}
+            maxSpeed={currentVideoId ? 2 : undefined}
+            onSubtitleLoad={handleSubtitleLoad}
+          />
+        </div>
+
+        {/* Right: embedding panel */}
+        <div className="embedding-layout-right">
+          {/* No transcript yet */}
+          {!hasTranscriptText && (
+            <div className="embedding-panel-placeholder">
+              <span>Load a YouTube video to enable embedding.</span>
+            </div>
+          )}
+
+          {/* Transcript available, not yet embedded */}
+          {hasTranscriptText && !isDone && !isEmbedding && (
+            <>
+              <div className="embedding-panel-form">
+                <select
+                  className="model-select"
+                  value={selectedModel}
+                  onChange={e => {
+                    const v = e.target.value as EmbeddingModelId
+                    setSelectedModel(v)
+                    localStorage.setItem('projector-model', v)
+                  }}
+                >
+                  {EMBEDDING_MODELS.map(m => (
+                    <option key={m.id} value={m.id}>{m.label}</option>
+                  ))}
+                </select>
+                <div className="embedding-panel-form-row">
+                  <button
+                    className="run-embedding-btn"
+                    onClick={handleRunEmbedding}
+                  >
+                    Run Embedding
+                  </button>
+                  <button className="show-segments-btn" onClick={handleShowSegments}>
+                    Show Segments{segments ? ` (${segments.length})` : ''}
+                  </button>
+                </div>
+                {embedPhase.status === 'error' && (
+                  <p className="embedding-panel-error">{embedPhase.message}</p>
+                )}
+              </div>
+              {!segments && (
+                <div className="embedding-panel-placeholder">
+                  <span>Run embedding to visualize segment relationships in 3D.</span>
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Embedding in progress */}
+          {isEmbedding && (
+            <div className="embedding-panel-progress">
+              {embedPhase.status === 'model-loading' && (
+                <div className="progress-wrap" style={{ width: '100%', maxWidth: 300 }}>
+                  <div className="progress-label">
+                    <div className="spinner" />
+                    <span>{embedPhase.progress > 0 ? `Downloading model… ${embedPhase.progress}%` : 'Initializing model…'}</span>
+                  </div>
+                  <div className={`progress-bar ${embedPhase.progress === 0 ? 'progress-bar--indeterminate' : ''}`}>
+                    <div className="progress-bar-fill" style={{ width: `${embedPhase.progress}%` }} />
+                  </div>
+                </div>
+              )}
+              {embedPhase.status === 'embedding' && (
+                <div className="progress-wrap" style={{ width: '100%', maxWidth: 300 }}>
+                  <div className="progress-label">
+                    <div className="spinner" />
+                    <span>Embedding {embedPhase.loaded + 1} / {embedPhase.total}</span>
+                  </div>
+                  <div className="progress-bar">
+                    <div className="progress-bar-fill" style={{ width: `${(embedPhase.loaded / embedPhase.total) * 100}%` }} />
+                  </div>
+                </div>
+              )}
+              {embedPhase.status === 'umap-running' && (
+                <div className="progress-wrap" style={{ width: '100%', maxWidth: 300 }}>
+                  <div className="progress-label">
+                    <div className="spinner" />
+                    <span>Reducing to 3D…</span>
+                  </div>
+                  <div className="progress-bar progress-bar--indeterminate">
+                    <div className="progress-bar-fill" />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Embedding done */}
+          {isDone && embedPhase.status === 'done' && segments && (
+            <>
+              <div className="embedding-panel-form" style={{ flexShrink: 0 }}>
+                <select
+                  className="model-select"
+                  value={selectedModel}
+                  onChange={e => {
+                    const v = e.target.value as EmbeddingModelId
+                    setSelectedModel(v)
+                    localStorage.setItem('projector-model', v)
+                  }}
+                >
+                  {EMBEDDING_MODELS.map(m => (
+                    <option key={m.id} value={m.id}>{m.label}</option>
+                  ))}
+                </select>
+                <div className="embedding-panel-form-row">
+                  <button className="show-segments-btn" onClick={handleShowSegments}>
+                    Show Segments ({segments.length})
+                  </button>
+                  <button
+                    className="run-embedding-btn"
+                    onClick={handleRunEmbedding}
+                  >
+                    Run Embedding
+                  </button>
+                </div>
+              </div>
+              <div className="embedding-panel-scatter">
+                <ScatterPlot3DV5
+                  points={embedPhase.points}
+                  labels={segments}
+                  highlightPosition={highlightIndex}
+                  onPointClick={handlePointClick}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {showSegmentsModal && segments && (
+        <SegmentsListModal
+          segments={segments}
+          onClose={() => setShowSegmentsModal(false)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/EmbeddingLayoutViewV5.tsx
+++ b/src/EmbeddingLayoutViewV5.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import TranscriptViewer from './TranscriptViewer'
 import YoutubePlayerEmbed from './YoutubePlayerEmbed'
+import ScatterPlot3D from './ScatterPlot3D'
 import ScatterPlot3DV5 from './ScatterPlot3DV5'
+import ScatterPlot3DV6 from './ScatterPlot3DV6'
 import SegmentsListModal from './SegmentsListModal'
 import { getEmbeddings, EMBEDDING_MODELS, type EmbeddingModelId } from './embedSegments'
 import { runUmap } from './runUmap'
@@ -108,6 +110,11 @@ export default function EmbeddingLayoutViewV5() {
   const [embedPhase, setEmbedPhase] = useState<EmbedPhase>({ status: 'idle' })
   const [segments, setSegments] = useState<string[] | null>(null)
   const [showSegmentsModal, setShowSegmentsModal] = useState(false)
+
+  type RendererType = 'original' | 'cividis-tube' | 'glow'
+  const [rendererType, setRendererType] = useState<RendererType>(() =>
+    (localStorage.getItem('scatter-renderer') as RendererType) ?? 'cividis-tube'
+  )
 
   // Scatter highlight state
   const [highlightIndex, setHighlightIndex] = useState<number | null>(null)
@@ -504,6 +511,19 @@ export default function EmbeddingLayoutViewV5() {
                     <option key={m.id} value={m.id}>{m.label}</option>
                   ))}
                 </select>
+                <select
+                  className="model-select"
+                  value={rendererType}
+                  onChange={e => {
+                    const v = e.target.value as RendererType
+                    setRendererType(v)
+                    localStorage.setItem('scatter-renderer', v)
+                  }}
+                >
+                  <option value="original">Points + Line</option>
+                  <option value="cividis-tube">Cividis Tube</option>
+                  <option value="glow">Glow (Shader)</option>
+                </select>
                 <div className="embedding-panel-form-row">
                   <button className="show-segments-btn" onClick={handleShowSegments}>
                     Show Segments ({segments.length})
@@ -517,12 +537,9 @@ export default function EmbeddingLayoutViewV5() {
                 </div>
               </div>
               <div className="embedding-panel-scatter">
-                <ScatterPlot3DV5
-                  points={embedPhase.points}
-                  labels={segments}
-                  highlightPosition={highlightIndex}
-                  onPointClick={handlePointClick}
-                />
+                {rendererType === 'original' && <ScatterPlot3D points={embedPhase.points} labels={segments} highlightPosition={highlightIndex} onPointClick={handlePointClick} />}
+                {rendererType === 'cividis-tube' && <ScatterPlot3DV5 points={embedPhase.points} labels={segments} highlightPosition={highlightIndex} onPointClick={handlePointClick} />}
+                {rendererType === 'glow' && <ScatterPlot3DV6 points={embedPhase.points} labels={segments} highlightPosition={highlightIndex} onPointClick={handlePointClick} />}
               </div>
             </>
           )}

--- a/src/ScatterPlot3D.css
+++ b/src/ScatterPlot3D.css
@@ -32,7 +32,12 @@
   background: rgba(0, 0, 0, 0.75);
   color: #fff;
 }
-.scatter-follow-btn.active {
+.scatter-follow-btn.tracking {
+  background: rgba(40, 100, 200, 0.35);
+  border-color: rgba(80, 140, 255, 0.6);
+  color: #fff;
+}
+.scatter-follow-btn.following {
   background: rgba(200, 50, 50, 0.35);
   border-color: rgba(255, 80, 80, 0.6);
   color: #fff;

--- a/src/ScatterPlot3D.css
+++ b/src/ScatterPlot3D.css
@@ -12,6 +12,32 @@
   height: 100% !important;
 }
 
+.scatter-follow-btn {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 4px;
+  font-size: 11px;
+  padding: 3px 8px;
+  cursor: pointer;
+  z-index: 10;
+  pointer-events: all;
+  user-select: none;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.scatter-follow-btn:hover {
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+}
+.scatter-follow-btn.active {
+  background: rgba(200, 50, 50, 0.35);
+  border-color: rgba(255, 80, 80, 0.6);
+  color: #fff;
+}
+
 .scatter-tooltip {
   position: absolute;
   pointer-events: none;

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -46,6 +46,8 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
   const prevFollowTargetRef = useRef(new THREE.Vector3())
   const prevPathTangentRef = useRef(new THREE.Vector3())
   const highlightPositionRef = useRef<number | null>(null)
+  const targetSphereRef = useRef(new THREE.Vector3())
+  const sphereVisibleRef = useRef(false)
   const normalizedRef = useRef<[number, number, number][]>([])
 
   // Build scene once
@@ -114,6 +116,13 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
     let animId = 0
     const animate = () => {
       animId = requestAnimationFrame(animate)
+      // Smoothly lerp sphere towards target position set by the highlight effect
+      if (sphereVisibleRef.current) {
+        highlightMesh.position.lerp(targetSphereRef.current, 0.2)
+        highlightMesh.visible = true
+      } else {
+        highlightMesh.visible = false
+      }
       const mode = followModeRef.current
       if (mode === 'tracking' && highlightMesh.visible) {
         controls.enabled = true
@@ -172,11 +181,9 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
     }
   }, [points])
 
-  // Highlight updates without scene rebuild — lerp between adjacent nodes for smooth motion
+  // Highlight updates — set target position; RAF lerps sphere towards it each frame
   useEffect(() => {
     highlightPositionRef.current = highlightPosition
-    const s = sceneRef.current
-    if (!s) return
     const normalized = normalizedRef.current
     if (highlightPosition !== null && normalized.length > 0) {
       const a = Math.max(0, Math.floor(highlightPosition))
@@ -184,13 +191,14 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
       const t = highlightPosition - a
       const pa = normalized[a]
       const pb = normalized[b]
-      const x = pa[0] + (pb[0] - pa[0]) * t
-      const y = pa[1] + (pb[1] - pa[1]) * t
-      const z = pa[2] + (pb[2] - pa[2]) * t
-      s.highlightMesh.position.set(x, y, z)
-      s.highlightMesh.visible = true
+      targetSphereRef.current.set(
+        pa[0] + (pb[0] - pa[0]) * t,
+        pa[1] + (pb[1] - pa[1]) * t,
+        pa[2] + (pb[2] - pa[2]) * t,
+      )
+      sphereVisibleRef.current = true
     } else {
-      s.highlightMesh.visible = false
+      sphereVisibleRef.current = false
     }
   }, [highlightPosition])
 

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -39,10 +39,12 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
     raycaster: THREE.Raycaster
     animId: number
   } | null>(null)
+  type FollowMode = 'static' | 'tracking' | 'following'
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null)
-  const [followCursor, setFollowCursor] = useState(false)
-  const followCursorRef = useRef(false)
+  const [followMode, setFollowMode] = useState<FollowMode>('static')
+  const followModeRef = useRef<FollowMode>('static')
   const prevFollowTargetRef = useRef(new THREE.Vector3())
+  const highlightPositionRef = useRef<number | null>(null)
   const normalizedRef = useRef<[number, number, number][]>([])
 
   // Build scene once
@@ -111,14 +113,32 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
     let animId = 0
     const animate = () => {
       animId = requestAnimationFrame(animate)
-      if (followCursorRef.current && highlightMesh.visible) {
+      const mode = followModeRef.current
+      if (mode === 'tracking' && highlightMesh.visible) {
+        controls.enabled = true
         const newTarget = highlightMesh.position.clone()
         const delta = newTarget.clone().sub(prevFollowTargetRef.current)
         camera.position.add(delta)
         controls.target.copy(newTarget)
         prevFollowTargetRef.current.copy(newTarget)
+        controls.update()
+      } else if (mode === 'following' && highlightMesh.visible) {
+        controls.enabled = false
+        const norm = normalizedRef.current
+        const hp = highlightPositionRef.current ?? 0
+        const a = Math.max(0, Math.min(norm.length - 2, Math.floor(hp)))
+        const pa = new THREE.Vector3(...norm[a])
+        const pb = new THREE.Vector3(...norm[a + 1])
+        const tangent = pb.clone().sub(pa).normalize()
+        const cursorPos = highlightMesh.position.clone()
+        camera.position.copy(cursorPos)
+          .addScaledVector(tangent, -0.6)
+          .add(new THREE.Vector3(0, 0.15, 0))
+        camera.lookAt(cursorPos.clone().addScaledVector(tangent, 0.2))
+      } else {
+        controls.enabled = true
+        controls.update()
       }
-      controls.update()
       renderer.render(scene, camera)
     }
     animate()
@@ -145,6 +165,7 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
 
   // Highlight updates without scene rebuild — lerp between adjacent nodes for smooth motion
   useEffect(() => {
+    highlightPositionRef.current = highlightPosition
     const s = sceneRef.current
     if (!s) return
     const normalized = normalizedRef.current
@@ -214,18 +235,19 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
         </div>
       )}
       <button
-        className={`scatter-follow-btn${followCursor ? ' active' : ''}`}
+        className={`scatter-follow-btn${followMode !== 'static' ? ` ${followMode}` : ''}`}
         onClick={e => {
           e.stopPropagation()
-          const next = !followCursor
-          setFollowCursor(next)
-          followCursorRef.current = next
-          if (next && sceneRef.current?.highlightMesh.visible) {
+          const modes: FollowMode[] = ['static', 'tracking', 'following']
+          const next = modes[(modes.indexOf(followMode) + 1) % modes.length]
+          setFollowMode(next)
+          followModeRef.current = next
+          if (next === 'tracking' && sceneRef.current?.highlightMesh.visible) {
             prevFollowTargetRef.current.copy(sceneRef.current.highlightMesh.position)
           }
         }}
       >
-        {followCursor ? 'Following ◎' : 'Follow ◎'}
+        {followMode === 'static' ? '◎ Static' : followMode === 'tracking' ? '◉ Tracking' : '⬤ Following'}
       </button>
     </div>
   )

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -44,6 +44,7 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
   const [followMode, setFollowMode] = useState<FollowMode>('static')
   const followModeRef = useRef<FollowMode>('static')
   const prevFollowTargetRef = useRef(new THREE.Vector3())
+  const prevPathTangentRef = useRef(new THREE.Vector3())
   const highlightPositionRef = useRef<number | null>(null)
   const normalizedRef = useRef<[number, number, number][]>([])
 
@@ -123,18 +124,26 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
         prevFollowTargetRef.current.copy(newTarget)
         controls.update()
       } else if (mode === 'following' && highlightMesh.visible) {
-        controls.enabled = false
+        controls.enabled = true
+        const newTarget = highlightMesh.position.clone()
         const norm = normalizedRef.current
         const hp = highlightPositionRef.current ?? 0
         const a = Math.max(0, Math.min(norm.length - 2, Math.floor(hp)))
-        const pa = new THREE.Vector3(...norm[a])
-        const pb = new THREE.Vector3(...norm[a + 1])
-        const tangent = pb.clone().sub(pa).normalize()
-        const cursorPos = highlightMesh.position.clone()
-        camera.position.copy(cursorPos)
-          .addScaledVector(tangent, -0.6)
-          .add(new THREE.Vector3(0, 0.15, 0))
-        camera.lookAt(cursorPos.clone().addScaledVector(tangent, 0.2))
+        const currTangent = new THREE.Vector3(...norm[a + 1]).sub(new THREE.Vector3(...norm[a])).normalize()
+        // Rotate camera's orbital offset to track path direction change
+        const oldOffset = camera.position.clone().sub(prevFollowTargetRef.current)
+        const prevTangent = prevPathTangentRef.current
+        if (prevTangent.lengthSq() > 0) {
+          const dot = prevTangent.dot(currTangent)
+          if (dot < 0.9999 && dot > -0.9999) {
+            oldOffset.applyQuaternion(new THREE.Quaternion().setFromUnitVectors(prevTangent, currTangent))
+          }
+        }
+        camera.position.copy(newTarget).add(oldOffset)
+        controls.target.copy(newTarget)
+        prevFollowTargetRef.current.copy(newTarget)
+        prevPathTangentRef.current.copy(currTangent)
+        controls.update()
       } else {
         controls.enabled = true
         controls.update()
@@ -242,8 +251,21 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
           const next = modes[(modes.indexOf(followMode) + 1) % modes.length]
           setFollowMode(next)
           followModeRef.current = next
-          if (next === 'tracking' && sceneRef.current?.highlightMesh.visible) {
-            prevFollowTargetRef.current.copy(sceneRef.current.highlightMesh.position)
+          const s = sceneRef.current
+          if (s?.highlightMesh.visible) {
+            if (next === 'tracking') {
+              prevFollowTargetRef.current.copy(s.highlightMesh.position)
+            } else if (next === 'following') {
+              const norm = normalizedRef.current
+              const hp = highlightPositionRef.current ?? 0
+              const a = Math.max(0, Math.min(norm.length - 2, Math.floor(hp)))
+              const tangent = new THREE.Vector3(...norm[a + 1]).sub(new THREE.Vector3(...norm[a])).normalize()
+              const cursorPos = s.highlightMesh.position.clone()
+              s.camera.position.copy(cursorPos).addScaledVector(tangent, -0.6).add(new THREE.Vector3(0, 0.15, 0))
+              s.controls.target.copy(cursorPos)
+              prevFollowTargetRef.current.copy(cursorPos)
+              prevPathTangentRef.current.copy(tangent)
+            }
           }
         }}
       >

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -40,6 +40,9 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
     animId: number
   } | null>(null)
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null)
+  const [followCursor, setFollowCursor] = useState(false)
+  const followCursorRef = useRef(false)
+  const prevFollowTargetRef = useRef(new THREE.Vector3())
   const normalizedRef = useRef<[number, number, number][]>([])
 
   // Build scene once
@@ -108,6 +111,13 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
     let animId = 0
     const animate = () => {
       animId = requestAnimationFrame(animate)
+      if (followCursorRef.current && highlightMesh.visible) {
+        const newTarget = highlightMesh.position.clone()
+        const delta = newTarget.clone().sub(prevFollowTargetRef.current)
+        camera.position.add(delta)
+        controls.target.copy(newTarget)
+        prevFollowTargetRef.current.copy(newTarget)
+      }
       controls.update()
       renderer.render(scene, camera)
     }
@@ -203,6 +213,20 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
           {tooltip.text}
         </div>
       )}
+      <button
+        className={`scatter-follow-btn${followCursor ? ' active' : ''}`}
+        onClick={e => {
+          e.stopPropagation()
+          const next = !followCursor
+          setFollowCursor(next)
+          followCursorRef.current = next
+          if (next && sceneRef.current?.highlightMesh.visible) {
+            prevFollowTargetRef.current.copy(sceneRef.current.highlightMesh.position)
+          }
+        }}
+      >
+        {followCursor ? 'Following ◎' : 'Follow ◎'}
+      </button>
     </div>
   )
 }

--- a/src/ScatterPlot3DV5.tsx
+++ b/src/ScatterPlot3DV5.tsx
@@ -68,6 +68,8 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
   const prevFollowTargetRef = useRef(new THREE.Vector3())
   const prevPathTangentRef = useRef(new THREE.Vector3())
   const highlightPositionRef = useRef<number | null>(null)
+  const targetSphereRef = useRef(new THREE.Vector3())
+  const sphereVisibleRef = useRef(false)
   const normalizedRef = useRef<[number, number, number][]>([])
 
   // Build scene once
@@ -162,6 +164,13 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
     let animId = 0
     const animate = () => {
       animId = requestAnimationFrame(animate)
+      // Smoothly lerp sphere towards target position set by the highlight effect
+      if (sphereVisibleRef.current) {
+        highlightMesh.position.lerp(targetSphereRef.current, 0.2)
+        highlightMesh.visible = true
+      } else {
+        highlightMesh.visible = false
+      }
       const mode = followModeRef.current
       if (mode === 'tracking' && highlightMesh.visible) {
         controls.enabled = true
@@ -219,7 +228,7 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
     }
   }, [points])
 
-  // Highlight updates — follow curve for smooth motion
+  // Highlight updates — set target position on curve; RAF lerps sphere towards it each frame
   useEffect(() => {
     highlightPositionRef.current = highlightPosition
     const s = sceneRef.current
@@ -228,10 +237,10 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
     if (highlightPosition !== null && normalized.length > 0) {
       const t = highlightPosition / (normalized.length - 1)
       const pos = s.curve.getPoint(Math.min(1, Math.max(0, t)))
-      s.highlightMesh.position.copy(pos)
-      s.highlightMesh.visible = true
+      targetSphereRef.current.copy(pos)
+      sphereVisibleRef.current = true
     } else {
-      s.highlightMesh.visible = false
+      sphereVisibleRef.current = false
     }
   }, [highlightPosition])
 

--- a/src/ScatterPlot3DV5.tsx
+++ b/src/ScatterPlot3DV5.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useRef, useState } from 'react'
+import * as THREE from 'three'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
+import './ScatterPlot3D.css'
+
+interface Props {
+  points: [number, number, number][]
+  labels: string[]
+  highlightPosition: number | null  // float: 1.7 = 70% between node 1 and 2
+  onPointClick: (index: number) => void
+}
+
+function normalize(points: [number, number, number][]): [number, number, number][] {
+  const mins = [Infinity, Infinity, Infinity]
+  const maxs = [-Infinity, -Infinity, -Infinity]
+  for (const p of points) {
+    for (let i = 0; i < 3; i++) {
+      if (p[i] < mins[i]) mins[i] = p[i]
+      if (p[i] > maxs[i]) maxs[i] = p[i]
+    }
+  }
+  return points.map(p =>
+    p.map((v, i) => {
+      const range = maxs[i] - mins[i]
+      return range === 0 ? 0 : ((v - mins[i]) / range) * 2 - 1
+    }) as [number, number, number]
+  )
+}
+
+function cividis(t: number): THREE.Color {
+  const lut = [
+    [0.000, 0.122, 0.302],  // t=0.0  dark navy
+    [0.122, 0.267, 0.420],  // t=0.1
+    [0.216, 0.342, 0.456],  // t=0.2
+    [0.300, 0.416, 0.469],  // t=0.3
+    [0.379, 0.488, 0.468],  // t=0.4
+    [0.456, 0.560, 0.450],  // t=0.5
+    [0.543, 0.630, 0.414],  // t=0.6
+    [0.643, 0.698, 0.352],  // t=0.7
+    [0.759, 0.764, 0.256],  // t=0.8
+    [0.877, 0.826, 0.125],  // t=0.9
+    [0.996, 0.908, 0.145],  // t=1.0  bright yellow
+  ]
+  const scaled = Math.min(0.9999, Math.max(0, t)) * (lut.length - 1)
+  const lo = Math.floor(scaled), hi = lo + 1
+  const f = scaled - lo
+  const [r, g, b] = lut[lo].map((v, i) => v + f * (lut[hi][i] - v))
+  return new THREE.Color(r, g, b)
+}
+
+export default function ScatterPlot3DV5({ points, labels, highlightPosition, onPointClick }: Props) {
+  const mountRef = useRef<HTMLDivElement>(null)
+  const sceneRef = useRef<{
+    renderer: THREE.WebGLRenderer
+    camera: THREE.PerspectiveCamera
+    controls: OrbitControls
+    scene: THREE.Scene
+    pointsMesh: THREE.Points
+    highlightMesh: THREE.Mesh
+    raycaster: THREE.Raycaster
+    animId: number
+    curve: THREE.CatmullRomCurve3
+  } | null>(null)
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null)
+  const normalizedRef = useRef<[number, number, number][]>([])
+
+  // Build scene once
+  useEffect(() => {
+    const mount = mountRef.current!
+    const w = mount.clientWidth
+    const h = mount.clientHeight
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true })
+    renderer.setSize(w, h)
+    renderer.setPixelRatio(window.devicePixelRatio)
+    const bgColor = getComputedStyle(document.documentElement).getPropertyValue('--bg').trim() || '#0f1117'
+    renderer.setClearColor(new THREE.Color(bgColor))
+    mount.appendChild(renderer.domElement)
+
+    const scene = new THREE.Scene()
+    const camera = new THREE.PerspectiveCamera(60, w / h, 0.01, 100)
+    camera.position.set(0, 0, 4)
+
+    const controls = new OrbitControls(camera, renderer.domElement)
+    controls.enableDamping = true
+    controls.dampingFactor = 0.08
+
+    const normalized = normalize(points)
+    normalizedRef.current = normalized
+    const n = normalized.length
+
+    // Points for raycasting (hover/click)
+    const positions = new Float32Array(n * 3)
+    const colors = new Float32Array(n * 3)
+    for (let i = 0; i < n; i++) {
+      positions[i * 3] = normalized[i][0]
+      positions[i * 3 + 1] = normalized[i][1]
+      positions[i * 3 + 2] = normalized[i][2]
+      const c = cividis(i / (n - 1))
+      colors[i * 3] = c.r
+      colors[i * 3 + 1] = c.g
+      colors[i * 3 + 2] = c.b
+    }
+
+    const geo = new THREE.BufferGeometry()
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3))
+    const mat = new THREE.PointsMaterial({ size: 0.025, sizeAttenuation: true, vertexColors: true })
+    const pointsMesh = new THREE.Points(geo, mat)
+    scene.add(pointsMesh)
+
+    // Curved tube path (protein-folding aesthetic)
+    const curve = new THREE.CatmullRomCurve3(
+      normalized.map(([x, y, z]) => new THREE.Vector3(x, y, z))
+    )
+
+    const TUBE_SEGMENTS = Math.max(64, normalized.length * 6)
+    const RADIAL_SEGMENTS = 10
+    const TUBE_RADIUS = 0.025
+
+    const tubeGeo = new THREE.TubeGeometry(curve, TUBE_SEGMENTS, TUBE_RADIUS, RADIAL_SEGMENTS, false)
+
+    const tubeColors = new Float32Array(tubeGeo.attributes.position.count * 3)
+    const vertsPerRing = RADIAL_SEGMENTS + 1
+    for (let v = 0; v < tubeGeo.attributes.position.count; v++) {
+      const ring = Math.floor(v / vertsPerRing)
+      const t = ring / TUBE_SEGMENTS
+      const c = cividis(t)
+      tubeColors[v * 3] = c.r
+      tubeColors[v * 3 + 1] = c.g
+      tubeColors[v * 3 + 2] = c.b
+    }
+    tubeGeo.setAttribute('color', new THREE.BufferAttribute(tubeColors, 3))
+
+    const tubeMat = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.6, metalness: 0.1 })
+    const tubeMesh = new THREE.Mesh(tubeGeo, tubeMat)
+    scene.add(tubeMesh)
+
+    // Lighting for MeshStandardMaterial
+    scene.add(new THREE.AmbientLight(0xffffff, 0.7))
+    scene.add(new THREE.DirectionalLight(0xffffff, 0.8))
+
+    // Highlight mesh (sphere)
+    const hlGeo = new THREE.SphereGeometry(0.04, 16, 16)
+    const hlMat = new THREE.MeshBasicMaterial({ color: 0xff2222 })
+    const highlightMesh = new THREE.Mesh(hlGeo, hlMat)
+    highlightMesh.visible = false
+    scene.add(highlightMesh)
+
+    const raycaster = new THREE.Raycaster()
+    raycaster.params.Points!.threshold = 0.05
+
+    let animId = 0
+    const animate = () => {
+      animId = requestAnimationFrame(animate)
+      controls.update()
+      renderer.render(scene, camera)
+    }
+    animate()
+
+    const ro = new ResizeObserver(() => {
+      const nw = mount.clientWidth
+      const nh = mount.clientHeight
+      renderer.setSize(nw, nh)
+      camera.aspect = nw / nh
+      camera.updateProjectionMatrix()
+    })
+    ro.observe(mount)
+
+    sceneRef.current = { renderer, camera, controls, scene, pointsMesh, highlightMesh, raycaster, animId, curve }
+
+    return () => {
+      cancelAnimationFrame(animId)
+      controls.dispose()
+      renderer.dispose()
+      ro.disconnect()
+      if (mount.contains(renderer.domElement)) mount.removeChild(renderer.domElement)
+    }
+  }, [points])
+
+  // Highlight updates — follow curve for smooth motion
+  useEffect(() => {
+    const s = sceneRef.current
+    if (!s) return
+    const normalized = normalizedRef.current
+    if (highlightPosition !== null && normalized.length > 0) {
+      const t = highlightPosition / (normalized.length - 1)
+      const pos = s.curve.getPoint(Math.min(1, Math.max(0, t)))
+      s.highlightMesh.position.copy(pos)
+      s.highlightMesh.visible = true
+    } else {
+      s.highlightMesh.visible = false
+    }
+  }, [highlightPosition])
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const s = sceneRef.current
+    if (!s) return
+    const rect = mountRef.current!.getBoundingClientRect()
+    const mouse = new THREE.Vector2(
+      ((e.clientX - rect.left) / rect.width) * 2 - 1,
+      -((e.clientY - rect.top) / rect.height) * 2 + 1
+    )
+    s.raycaster.setFromCamera(mouse, s.camera)
+    const hits = s.raycaster.intersectObject(s.pointsMesh)
+    if (hits.length > 0) {
+      const idx = hits[0].index!
+      setTooltip({ x: e.clientX - rect.left, y: e.clientY - rect.top, text: labels[idx] })
+    } else {
+      setTooltip(null)
+    }
+  }
+
+  const mouseDownRef = useRef<{ x: number; y: number } | null>(null)
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    mouseDownRef.current = { x: e.clientX, y: e.clientY }
+  }
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const down = mouseDownRef.current
+    if (!down) return
+    const dx = e.clientX - down.x
+    const dy = e.clientY - down.y
+    if (dx * dx + dy * dy > 25) return // >5px movement = drag, not click
+    const s = sceneRef.current
+    if (!s) return
+    const rect = mountRef.current!.getBoundingClientRect()
+    const mouse = new THREE.Vector2(
+      ((e.clientX - rect.left) / rect.width) * 2 - 1,
+      -((e.clientY - rect.top) / rect.height) * 2 + 1
+    )
+    s.raycaster.setFromCamera(mouse, s.camera)
+    const hits = s.raycaster.intersectObject(s.pointsMesh)
+    if (hits.length > 0) onPointClick(hits[0].index!)
+  }
+
+  return (
+    <div className="scatter-wrap" ref={mountRef} onMouseMove={handleMouseMove} onMouseDown={handleMouseDown} onClick={handleClick}>
+      {tooltip && (
+        <div className="scatter-tooltip" style={{ left: tooltip.x + 12, top: tooltip.y + 12 }}>
+          {tooltip.text}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ScatterPlot3DV5.tsx
+++ b/src/ScatterPlot3DV5.tsx
@@ -62,6 +62,9 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
     curve: THREE.CatmullRomCurve3
   } | null>(null)
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null)
+  const [followCursor, setFollowCursor] = useState(false)
+  const followCursorRef = useRef(false)
+  const prevFollowTargetRef = useRef(new THREE.Vector3())
   const normalizedRef = useRef<[number, number, number][]>([])
 
   // Build scene once
@@ -156,6 +159,13 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
     let animId = 0
     const animate = () => {
       animId = requestAnimationFrame(animate)
+      if (followCursorRef.current && highlightMesh.visible) {
+        const newTarget = highlightMesh.position.clone()
+        const delta = newTarget.clone().sub(prevFollowTargetRef.current)
+        camera.position.add(delta)
+        controls.target.copy(newTarget)
+        prevFollowTargetRef.current.copy(newTarget)
+      }
       controls.update()
       renderer.render(scene, camera)
     }
@@ -245,6 +255,20 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
           {tooltip.text}
         </div>
       )}
+      <button
+        className={`scatter-follow-btn${followCursor ? ' active' : ''}`}
+        onClick={e => {
+          e.stopPropagation()
+          const next = !followCursor
+          setFollowCursor(next)
+          followCursorRef.current = next
+          if (next && sceneRef.current?.highlightMesh.visible) {
+            prevFollowTargetRef.current.copy(sceneRef.current.highlightMesh.position)
+          }
+        }}
+      >
+        {followCursor ? 'Following ◎' : 'Follow ◎'}
+      </button>
     </div>
   )
 }

--- a/src/ScatterPlot3DV5.tsx
+++ b/src/ScatterPlot3DV5.tsx
@@ -126,9 +126,12 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
       const ring = Math.floor(v / vertsPerRing)
       const t = ring / TUBE_SEGMENTS
       const c = cividis(t)
-      tubeColors[v * 3] = c.r
-      tubeColors[v * 3 + 1] = c.g
-      tubeColors[v * 3 + 2] = c.b
+      // Alternate brightness between node-to-node segments to show spacing
+      const segIdx = Math.floor(Math.min(t * (normalized.length - 1), normalized.length - 2))
+      const bright = segIdx % 2 === 0 ? 1.2 : 0.7
+      tubeColors[v * 3] = Math.min(1, c.r * bright)
+      tubeColors[v * 3 + 1] = Math.min(1, c.g * bright)
+      tubeColors[v * 3 + 2] = Math.min(1, c.b * bright)
     }
     tubeGeo.setAttribute('color', new THREE.BufferAttribute(tubeColors, 3))
 

--- a/src/ScatterPlot3DV5.tsx
+++ b/src/ScatterPlot3DV5.tsx
@@ -66,6 +66,7 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
   const [followMode, setFollowMode] = useState<FollowMode>('static')
   const followModeRef = useRef<FollowMode>('static')
   const prevFollowTargetRef = useRef(new THREE.Vector3())
+  const prevPathTangentRef = useRef(new THREE.Vector3())
   const highlightPositionRef = useRef<number | null>(null)
   const normalizedRef = useRef<[number, number, number][]>([])
 
@@ -171,15 +172,25 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
         prevFollowTargetRef.current.copy(newTarget)
         controls.update()
       } else if (mode === 'following' && highlightMesh.visible) {
-        controls.enabled = false
+        controls.enabled = true
+        const newTarget = highlightMesh.position.clone()
         const hp = highlightPositionRef.current ?? 0
         const t = Math.max(0.0001, Math.min(0.9999, hp / (normalized.length - 1)))
-        const tangent = curve.getTangent(t)
-        const cursorPos = highlightMesh.position.clone()
-        camera.position.copy(cursorPos)
-          .addScaledVector(tangent, -0.6)
-          .add(new THREE.Vector3(0, 0.15, 0))
-        camera.lookAt(cursorPos.clone().addScaledVector(tangent, 0.2))
+        const currTangent = curve.getTangent(t)
+        // Rotate camera's orbital offset to track path direction change
+        const oldOffset = camera.position.clone().sub(prevFollowTargetRef.current)
+        const prevTangent = prevPathTangentRef.current
+        if (prevTangent.lengthSq() > 0) {
+          const dot = prevTangent.dot(currTangent)
+          if (dot < 0.9999 && dot > -0.9999) {
+            oldOffset.applyQuaternion(new THREE.Quaternion().setFromUnitVectors(prevTangent, currTangent))
+          }
+        }
+        camera.position.copy(newTarget).add(oldOffset)
+        controls.target.copy(newTarget)
+        prevFollowTargetRef.current.copy(newTarget)
+        prevPathTangentRef.current.copy(currTangent)
+        controls.update()
       } else {
         controls.enabled = true
         controls.update()
@@ -281,8 +292,20 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
           const next = modes[(modes.indexOf(followMode) + 1) % modes.length]
           setFollowMode(next)
           followModeRef.current = next
-          if (next === 'tracking' && sceneRef.current?.highlightMesh.visible) {
-            prevFollowTargetRef.current.copy(sceneRef.current.highlightMesh.position)
+          const s = sceneRef.current
+          if (s?.highlightMesh.visible) {
+            if (next === 'tracking') {
+              prevFollowTargetRef.current.copy(s.highlightMesh.position)
+            } else if (next === 'following') {
+              const hp = highlightPositionRef.current ?? 0
+              const t = Math.max(0.0001, Math.min(0.9999, hp / (normalizedRef.current.length - 1)))
+              const tangent = s.curve.getTangent(t)
+              const cursorPos = s.highlightMesh.position.clone()
+              s.camera.position.copy(cursorPos).addScaledVector(tangent, -0.6).add(new THREE.Vector3(0, 0.15, 0))
+              s.controls.target.copy(cursorPos)
+              prevFollowTargetRef.current.copy(cursorPos)
+              prevPathTangentRef.current.copy(tangent)
+            }
           }
         }}
       >

--- a/src/ScatterPlot3DV5.tsx
+++ b/src/ScatterPlot3DV5.tsx
@@ -61,10 +61,12 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
     animId: number
     curve: THREE.CatmullRomCurve3
   } | null>(null)
+  type FollowMode = 'static' | 'tracking' | 'following'
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null)
-  const [followCursor, setFollowCursor] = useState(false)
-  const followCursorRef = useRef(false)
+  const [followMode, setFollowMode] = useState<FollowMode>('static')
+  const followModeRef = useRef<FollowMode>('static')
   const prevFollowTargetRef = useRef(new THREE.Vector3())
+  const highlightPositionRef = useRef<number | null>(null)
   const normalizedRef = useRef<[number, number, number][]>([])
 
   // Build scene once
@@ -159,14 +161,29 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
     let animId = 0
     const animate = () => {
       animId = requestAnimationFrame(animate)
-      if (followCursorRef.current && highlightMesh.visible) {
+      const mode = followModeRef.current
+      if (mode === 'tracking' && highlightMesh.visible) {
+        controls.enabled = true
         const newTarget = highlightMesh.position.clone()
         const delta = newTarget.clone().sub(prevFollowTargetRef.current)
         camera.position.add(delta)
         controls.target.copy(newTarget)
         prevFollowTargetRef.current.copy(newTarget)
+        controls.update()
+      } else if (mode === 'following' && highlightMesh.visible) {
+        controls.enabled = false
+        const hp = highlightPositionRef.current ?? 0
+        const t = Math.max(0.0001, Math.min(0.9999, hp / (normalized.length - 1)))
+        const tangent = curve.getTangent(t)
+        const cursorPos = highlightMesh.position.clone()
+        camera.position.copy(cursorPos)
+          .addScaledVector(tangent, -0.6)
+          .add(new THREE.Vector3(0, 0.15, 0))
+        camera.lookAt(cursorPos.clone().addScaledVector(tangent, 0.2))
+      } else {
+        controls.enabled = true
+        controls.update()
       }
-      controls.update()
       renderer.render(scene, camera)
     }
     animate()
@@ -193,6 +210,7 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
 
   // Highlight updates — follow curve for smooth motion
   useEffect(() => {
+    highlightPositionRef.current = highlightPosition
     const s = sceneRef.current
     if (!s) return
     const normalized = normalizedRef.current
@@ -256,18 +274,19 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
         </div>
       )}
       <button
-        className={`scatter-follow-btn${followCursor ? ' active' : ''}`}
+        className={`scatter-follow-btn${followMode !== 'static' ? ` ${followMode}` : ''}`}
         onClick={e => {
           e.stopPropagation()
-          const next = !followCursor
-          setFollowCursor(next)
-          followCursorRef.current = next
-          if (next && sceneRef.current?.highlightMesh.visible) {
+          const modes: FollowMode[] = ['static', 'tracking', 'following']
+          const next = modes[(modes.indexOf(followMode) + 1) % modes.length]
+          setFollowMode(next)
+          followModeRef.current = next
+          if (next === 'tracking' && sceneRef.current?.highlightMesh.visible) {
             prevFollowTargetRef.current.copy(sceneRef.current.highlightMesh.position)
           }
         }}
       >
-        {followCursor ? 'Following ◎' : 'Follow ◎'}
+        {followMode === 'static' ? '◎ Static' : followMode === 'tracking' ? '◉ Tracking' : '⬤ Following'}
       </button>
     </div>
   )

--- a/src/ScatterPlot3DV6.tsx
+++ b/src/ScatterPlot3DV6.tsx
@@ -103,6 +103,7 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
   const [followMode, setFollowMode] = useState<FollowMode>('static')
   const followModeRef = useRef<FollowMode>('static')
   const prevFollowTargetRef = useRef(new THREE.Vector3())
+  const prevPathTangentRef = useRef(new THREE.Vector3())
   const highlightPositionRef = useRef<number | null>(null)
   const normalizedRef = useRef<[number, number, number][]>([])
 
@@ -194,18 +195,26 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
         prevFollowTargetRef.current.copy(newTarget)
         controls.update()
       } else if (mode === 'following' && highlightMesh.visible) {
-        controls.enabled = false
+        controls.enabled = true
+        const newTarget = highlightMesh.position.clone()
         const norm = normalizedRef.current
         const hp = highlightPositionRef.current ?? 0
         const a = Math.max(0, Math.min(norm.length - 2, Math.floor(hp)))
-        const pa = new THREE.Vector3(...norm[a])
-        const pb = new THREE.Vector3(...norm[a + 1])
-        const tangent = pb.clone().sub(pa).normalize()
-        const cursorPos = highlightMesh.position.clone()
-        camera.position.copy(cursorPos)
-          .addScaledVector(tangent, -0.6)
-          .add(new THREE.Vector3(0, 0.15, 0))
-        camera.lookAt(cursorPos.clone().addScaledVector(tangent, 0.2))
+        const currTangent = new THREE.Vector3(...norm[a + 1]).sub(new THREE.Vector3(...norm[a])).normalize()
+        // Rotate camera's orbital offset to track path direction change
+        const oldOffset = camera.position.clone().sub(prevFollowTargetRef.current)
+        const prevTangent = prevPathTangentRef.current
+        if (prevTangent.lengthSq() > 0) {
+          const dot = prevTangent.dot(currTangent)
+          if (dot < 0.9999 && dot > -0.9999) {
+            oldOffset.applyQuaternion(new THREE.Quaternion().setFromUnitVectors(prevTangent, currTangent))
+          }
+        }
+        camera.position.copy(newTarget).add(oldOffset)
+        controls.target.copy(newTarget)
+        prevFollowTargetRef.current.copy(newTarget)
+        prevPathTangentRef.current.copy(currTangent)
+        controls.update()
       } else {
         controls.enabled = true
         controls.update()
@@ -309,8 +318,21 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
           const next = modes[(modes.indexOf(followMode) + 1) % modes.length]
           setFollowMode(next)
           followModeRef.current = next
-          if (next === 'tracking' && sceneRef.current?.highlightMesh.visible) {
-            prevFollowTargetRef.current.copy(sceneRef.current.highlightMesh.position)
+          const s = sceneRef.current
+          if (s?.highlightMesh.visible) {
+            if (next === 'tracking') {
+              prevFollowTargetRef.current.copy(s.highlightMesh.position)
+            } else if (next === 'following') {
+              const norm = normalizedRef.current
+              const hp = highlightPositionRef.current ?? 0
+              const a = Math.max(0, Math.min(norm.length - 2, Math.floor(hp)))
+              const tangent = new THREE.Vector3(...norm[a + 1]).sub(new THREE.Vector3(...norm[a])).normalize()
+              const cursorPos = s.highlightMesh.position.clone()
+              s.camera.position.copy(cursorPos).addScaledVector(tangent, -0.6).add(new THREE.Vector3(0, 0.15, 0))
+              s.controls.target.copy(cursorPos)
+              prevFollowTargetRef.current.copy(cursorPos)
+              prevPathTangentRef.current.copy(tangent)
+            }
           }
         }}
       >

--- a/src/ScatterPlot3DV6.tsx
+++ b/src/ScatterPlot3DV6.tsx
@@ -98,10 +98,12 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
     composer: EffectComposer
     uniforms: { uTime: { value: number } }
   } | null>(null)
+  type FollowMode = 'static' | 'tracking' | 'following'
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null)
-  const [followCursor, setFollowCursor] = useState(false)
-  const followCursorRef = useRef(false)
+  const [followMode, setFollowMode] = useState<FollowMode>('static')
+  const followModeRef = useRef<FollowMode>('static')
   const prevFollowTargetRef = useRef(new THREE.Vector3())
+  const highlightPositionRef = useRef<number | null>(null)
   const normalizedRef = useRef<[number, number, number][]>([])
 
   useEffect(() => {
@@ -182,14 +184,32 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
     const animate = () => {
       animId = requestAnimationFrame(animate)
       uniforms.uTime.value += 0.016
-      if (followCursorRef.current && highlightMesh.visible) {
+      const mode = followModeRef.current
+      if (mode === 'tracking' && highlightMesh.visible) {
+        controls.enabled = true
         const newTarget = highlightMesh.position.clone()
         const delta = newTarget.clone().sub(prevFollowTargetRef.current)
         camera.position.add(delta)
         controls.target.copy(newTarget)
         prevFollowTargetRef.current.copy(newTarget)
+        controls.update()
+      } else if (mode === 'following' && highlightMesh.visible) {
+        controls.enabled = false
+        const norm = normalizedRef.current
+        const hp = highlightPositionRef.current ?? 0
+        const a = Math.max(0, Math.min(norm.length - 2, Math.floor(hp)))
+        const pa = new THREE.Vector3(...norm[a])
+        const pb = new THREE.Vector3(...norm[a + 1])
+        const tangent = pb.clone().sub(pa).normalize()
+        const cursorPos = highlightMesh.position.clone()
+        camera.position.copy(cursorPos)
+          .addScaledVector(tangent, -0.6)
+          .add(new THREE.Vector3(0, 0.15, 0))
+        camera.lookAt(cursorPos.clone().addScaledVector(tangent, 0.2))
+      } else {
+        controls.enabled = true
+        controls.update()
       }
-      controls.update()
       composer.render()
     }
     animate()
@@ -218,6 +238,7 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
   }, [points])
 
   useEffect(() => {
+    highlightPositionRef.current = highlightPosition
     const s = sceneRef.current
     if (!s) return
     const normalized = normalizedRef.current
@@ -281,18 +302,19 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
         </div>
       )}
       <button
-        className={`scatter-follow-btn${followCursor ? ' active' : ''}`}
+        className={`scatter-follow-btn${followMode !== 'static' ? ` ${followMode}` : ''}`}
         onClick={e => {
           e.stopPropagation()
-          const next = !followCursor
-          setFollowCursor(next)
-          followCursorRef.current = next
-          if (next && sceneRef.current?.highlightMesh.visible) {
+          const modes: FollowMode[] = ['static', 'tracking', 'following']
+          const next = modes[(modes.indexOf(followMode) + 1) % modes.length]
+          setFollowMode(next)
+          followModeRef.current = next
+          if (next === 'tracking' && sceneRef.current?.highlightMesh.visible) {
             prevFollowTargetRef.current.copy(sceneRef.current.highlightMesh.position)
           }
         }}
       >
-        {followCursor ? 'Following ◎' : 'Follow ◎'}
+        {followMode === 'static' ? '◎ Static' : followMode === 'tracking' ? '◉ Tracking' : '⬤ Following'}
       </button>
     </div>
   )

--- a/src/ScatterPlot3DV6.tsx
+++ b/src/ScatterPlot3DV6.tsx
@@ -31,19 +31,14 @@ function normalize(points: [number, number, number][]): [number, number, number]
   )
 }
 
-function cividis(t: number): THREE.Color {
+function glowPalette(t: number): THREE.Color {
+  // Vivid blue → cyan → bright yellow — optimized for bloom glow
   const lut = [
-    [0.000, 0.122, 0.302],
-    [0.122, 0.267, 0.420],
-    [0.216, 0.342, 0.456],
-    [0.300, 0.416, 0.469],
-    [0.379, 0.488, 0.468],
-    [0.456, 0.560, 0.450],
-    [0.543, 0.630, 0.414],
-    [0.643, 0.698, 0.352],
-    [0.759, 0.764, 0.256],
-    [0.877, 0.826, 0.125],
-    [0.996, 0.908, 0.145],
+    [0.10, 0.30, 1.00],  // t=0.00  vivid blue
+    [0.00, 0.55, 1.00],  // t=0.25  dodger blue
+    [0.00, 0.90, 0.95],  // t=0.50  cyan
+    [0.60, 1.00, 0.20],  // t=0.75  yellow-green
+    [1.00, 0.95, 0.05],  // t=1.00  bright yellow
   ]
   const scaled = Math.min(0.9999, Math.max(0, t)) * (lut.length - 1)
   const lo = Math.floor(scaled), hi = lo + 1
@@ -142,7 +137,7 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
       positions[i * 3] = normalized[i][0]
       positions[i * 3 + 1] = normalized[i][1]
       positions[i * 3 + 2] = normalized[i][2]
-      const c = cividis(i / (n - 1))
+      const c = glowPalette(i / (n - 1))
       aColors[i * 3] = c.r
       aColors[i * 3 + 1] = c.g
       aColors[i * 3 + 2] = c.b

--- a/src/ScatterPlot3DV6.tsx
+++ b/src/ScatterPlot3DV6.tsx
@@ -99,6 +99,9 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
     uniforms: { uTime: { value: number } }
   } | null>(null)
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null)
+  const [followCursor, setFollowCursor] = useState(false)
+  const followCursorRef = useRef(false)
+  const prevFollowTargetRef = useRef(new THREE.Vector3())
   const normalizedRef = useRef<[number, number, number][]>([])
 
   useEffect(() => {
@@ -179,6 +182,13 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
     const animate = () => {
       animId = requestAnimationFrame(animate)
       uniforms.uTime.value += 0.016
+      if (followCursorRef.current && highlightMesh.visible) {
+        const newTarget = highlightMesh.position.clone()
+        const delta = newTarget.clone().sub(prevFollowTargetRef.current)
+        camera.position.add(delta)
+        controls.target.copy(newTarget)
+        prevFollowTargetRef.current.copy(newTarget)
+      }
       controls.update()
       composer.render()
     }
@@ -270,6 +280,20 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
           {tooltip.text}
         </div>
       )}
+      <button
+        className={`scatter-follow-btn${followCursor ? ' active' : ''}`}
+        onClick={e => {
+          e.stopPropagation()
+          const next = !followCursor
+          setFollowCursor(next)
+          followCursorRef.current = next
+          if (next && sceneRef.current?.highlightMesh.visible) {
+            prevFollowTargetRef.current.copy(sceneRef.current.highlightMesh.position)
+          }
+        }}
+      >
+        {followCursor ? 'Following ◎' : 'Follow ◎'}
+      </button>
     </div>
   )
 }

--- a/src/ScatterPlot3DV6.tsx
+++ b/src/ScatterPlot3DV6.tsx
@@ -63,6 +63,22 @@ void main() {
 }
 `
 
+// Smaller variant for fill particles between nodes
+const fillVertexShader = /* glsl */`
+attribute vec3 aColor;
+attribute float aSeed;
+varying vec3 vColor;
+varying float vSeed;
+
+void main() {
+  vColor = aColor;
+  vSeed = aSeed;
+  vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+  gl_PointSize = (0.7 + 1.2 / -mvPosition.z) * (0.4 + 0.6 * aSeed);
+  gl_Position = projectionMatrix * mvPosition;
+}
+`
+
 const fragmentShader = /* glsl */`
 varying vec3 vColor;
 varying float vSeed;
@@ -161,6 +177,39 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
     const pointsMesh = new THREE.Points(geo, mat)
     scene.add(pointsMesh)
 
+    // Fill particles — linearly interpolated between adjacent nodes
+    const FILL_PER_SEG = 12
+    const fillCount = (n - 1) * FILL_PER_SEG
+    const fillPositions = new Float32Array(fillCount * 3)
+    const fillColors = new Float32Array(fillCount * 3)
+    const fillSeeds = new Float32Array(fillCount)
+    for (let i = 0; i < n - 1; i++) {
+      for (let j = 0; j < FILL_PER_SEG; j++) {
+        const f = (j + 1) / (FILL_PER_SEG + 1)
+        const idx = i * FILL_PER_SEG + j
+        fillPositions[idx * 3]     = normalized[i][0] + (normalized[i + 1][0] - normalized[i][0]) * f
+        fillPositions[idx * 3 + 1] = normalized[i][1] + (normalized[i + 1][1] - normalized[i][1]) * f
+        fillPositions[idx * 3 + 2] = normalized[i][2] + (normalized[i + 1][2] - normalized[i][2]) * f
+        const c = glowPalette((i + f) / (n - 1))
+        fillColors[idx * 3] = c.r; fillColors[idx * 3 + 1] = c.g; fillColors[idx * 3 + 2] = c.b
+        fillSeeds[idx] = Math.random()
+      }
+    }
+    const fillGeo = new THREE.BufferGeometry()
+    fillGeo.setAttribute('position', new THREE.BufferAttribute(fillPositions, 3))
+    fillGeo.setAttribute('aColor',   new THREE.BufferAttribute(fillColors, 3))
+    fillGeo.setAttribute('aSeed',    new THREE.BufferAttribute(fillSeeds, 1))
+    // Share uTime with node material so both pulse in sync
+    const fillMat = new THREE.ShaderMaterial({
+      uniforms: { uTime: uniforms.uTime },
+      vertexShader: fillVertexShader,
+      fragmentShader,
+      transparent: true,
+      depthWrite: false,
+    })
+    const fillMesh = new THREE.Points(fillGeo, fillMat)
+    scene.add(fillMesh)
+
     // Highlight sphere
     const hlGeo = new THREE.SphereGeometry(0.05, 16, 16)
     const hlMat = new THREE.MeshBasicMaterial({ color: 0xff3333 })
@@ -246,6 +295,8 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
       composer.dispose()
       renderer.dispose()
       ro.disconnect()
+      fillGeo.dispose()
+      fillMat.dispose()
       if (mount.contains(renderer.domElement)) mount.removeChild(renderer.domElement)
     }
   }, [points])

--- a/src/ScatterPlot3DV6.tsx
+++ b/src/ScatterPlot3DV6.tsx
@@ -105,6 +105,8 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
   const prevFollowTargetRef = useRef(new THREE.Vector3())
   const prevPathTangentRef = useRef(new THREE.Vector3())
   const highlightPositionRef = useRef<number | null>(null)
+  const targetSphereRef = useRef(new THREE.Vector3())
+  const sphereVisibleRef = useRef(false)
   const normalizedRef = useRef<[number, number, number][]>([])
 
   useEffect(() => {
@@ -185,6 +187,13 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
     const animate = () => {
       animId = requestAnimationFrame(animate)
       uniforms.uTime.value += 0.016
+      // Smoothly lerp sphere towards target position set by the highlight effect
+      if (sphereVisibleRef.current) {
+        highlightMesh.position.lerp(targetSphereRef.current, 0.2)
+        highlightMesh.visible = true
+      } else {
+        highlightMesh.visible = false
+      }
       const mode = followModeRef.current
       if (mode === 'tracking' && highlightMesh.visible) {
         controls.enabled = true
@@ -246,24 +255,23 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
     }
   }, [points])
 
+  // Highlight updates — set target position; RAF lerps sphere towards it each frame
   useEffect(() => {
     highlightPositionRef.current = highlightPosition
-    const s = sceneRef.current
-    if (!s) return
     const normalized = normalizedRef.current
     if (highlightPosition !== null && normalized.length > 0) {
       const a = Math.max(0, Math.floor(highlightPosition))
       const b = Math.min(normalized.length - 1, Math.ceil(highlightPosition))
       const t = highlightPosition - a
       const pa = normalized[a], pb = normalized[b]
-      s.highlightMesh.position.set(
+      targetSphereRef.current.set(
         pa[0] + (pb[0] - pa[0]) * t,
         pa[1] + (pb[1] - pa[1]) * t,
         pa[2] + (pb[2] - pa[2]) * t,
       )
-      s.highlightMesh.visible = true
+      sphereVisibleRef.current = true
     } else {
-      s.highlightMesh.visible = false
+      sphereVisibleRef.current = false
     }
   }, [highlightPosition])
 

--- a/src/ScatterPlot3DV6.tsx
+++ b/src/ScatterPlot3DV6.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useRef, useState } from 'react'
+import * as THREE from 'three'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js'
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js'
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js'
+import './ScatterPlot3D.css'
+
+interface Props {
+  points: [number, number, number][]
+  labels: string[]
+  highlightPosition: number | null
+  onPointClick: (index: number) => void
+}
+
+function normalize(points: [number, number, number][]): [number, number, number][] {
+  const mins = [Infinity, Infinity, Infinity]
+  const maxs = [-Infinity, -Infinity, -Infinity]
+  for (const p of points) {
+    for (let i = 0; i < 3; i++) {
+      if (p[i] < mins[i]) mins[i] = p[i]
+      if (p[i] > maxs[i]) maxs[i] = p[i]
+    }
+  }
+  return points.map(p =>
+    p.map((v, i) => {
+      const range = maxs[i] - mins[i]
+      return range === 0 ? 0 : ((v - mins[i]) / range) * 2 - 1
+    }) as [number, number, number]
+  )
+}
+
+function cividis(t: number): THREE.Color {
+  const lut = [
+    [0.000, 0.122, 0.302],
+    [0.122, 0.267, 0.420],
+    [0.216, 0.342, 0.456],
+    [0.300, 0.416, 0.469],
+    [0.379, 0.488, 0.468],
+    [0.456, 0.560, 0.450],
+    [0.543, 0.630, 0.414],
+    [0.643, 0.698, 0.352],
+    [0.759, 0.764, 0.256],
+    [0.877, 0.826, 0.125],
+    [0.996, 0.908, 0.145],
+  ]
+  const scaled = Math.min(0.9999, Math.max(0, t)) * (lut.length - 1)
+  const lo = Math.floor(scaled), hi = lo + 1
+  const f = scaled - lo
+  const [r, g, b] = lut[lo].map((v, i) => v + f * (lut[hi][i] - v))
+  return new THREE.Color(r, g, b)
+}
+
+const vertexShader = /* glsl */`
+attribute vec3 aColor;
+attribute float aSeed;
+varying vec3 vColor;
+varying float vSeed;
+
+void main() {
+  vColor = aColor;
+  vSeed = aSeed;
+  vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+  // Size scales with camera distance; random seed adds per-point variation
+  gl_PointSize = (1.5 + 2.5 / -mvPosition.z) * (0.6 + 0.8 * aSeed);
+  gl_Position = projectionMatrix * mvPosition;
+}
+`
+
+const fragmentShader = /* glsl */`
+varying vec3 vColor;
+varying float vSeed;
+uniform float uTime;
+
+void main() {
+  vec2 uv = gl_PointCoord - 0.5;
+  float d = length(uv);
+  if (d > 0.5) discard;
+  float alpha = 1.0 - smoothstep(0.25, 0.5, d);
+  // Each point pulses at its own phase, derived from its random seed
+  float pulse = 0.65 + 0.35 * sin(vSeed * 50.0 + uTime * 2.5);
+  gl_FragColor = vec4(vColor * pulse, alpha);
+}
+`
+
+export default function ScatterPlot3DV6({ points, labels, highlightPosition, onPointClick }: Props) {
+  const mountRef = useRef<HTMLDivElement>(null)
+  const sceneRef = useRef<{
+    renderer: THREE.WebGLRenderer
+    camera: THREE.PerspectiveCamera
+    controls: OrbitControls
+    scene: THREE.Scene
+    pointsMesh: THREE.Points
+    highlightMesh: THREE.Mesh
+    raycaster: THREE.Raycaster
+    animId: number
+    composer: EffectComposer
+    uniforms: { uTime: { value: number } }
+  } | null>(null)
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null)
+  const normalizedRef = useRef<[number, number, number][]>([])
+
+  useEffect(() => {
+    const mount = mountRef.current!
+    const w = mount.clientWidth
+    const h = mount.clientHeight
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true })
+    renderer.setSize(w, h)
+    renderer.setPixelRatio(window.devicePixelRatio)
+    renderer.toneMapping = THREE.ACESFilmicToneMapping
+    renderer.toneMappingExposure = 1.0
+    mount.appendChild(renderer.domElement)
+
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color(0x080b10)
+
+    const camera = new THREE.PerspectiveCamera(60, w / h, 0.01, 100)
+    camera.position.set(0, 0, 4)
+
+    const controls = new OrbitControls(camera, renderer.domElement)
+    controls.enableDamping = true
+    controls.dampingFactor = 0.08
+
+    const normalized = normalize(points)
+    normalizedRef.current = normalized
+    const n = normalized.length
+
+    const positions = new Float32Array(n * 3)
+    const aColors = new Float32Array(n * 3)
+    const aSeeds = new Float32Array(n)
+    for (let i = 0; i < n; i++) {
+      positions[i * 3] = normalized[i][0]
+      positions[i * 3 + 1] = normalized[i][1]
+      positions[i * 3 + 2] = normalized[i][2]
+      const c = cividis(i / (n - 1))
+      aColors[i * 3] = c.r
+      aColors[i * 3 + 1] = c.g
+      aColors[i * 3 + 2] = c.b
+      aSeeds[i] = Math.random()
+    }
+
+    const geo = new THREE.BufferGeometry()
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+    geo.setAttribute('aColor', new THREE.BufferAttribute(aColors, 3))
+    geo.setAttribute('aSeed', new THREE.BufferAttribute(aSeeds, 1))
+
+    const uniforms = { uTime: { value: 0 } }
+    const mat = new THREE.ShaderMaterial({
+      uniforms,
+      vertexShader,
+      fragmentShader,
+      transparent: true,
+      depthWrite: false,
+    })
+
+    const pointsMesh = new THREE.Points(geo, mat)
+    scene.add(pointsMesh)
+
+    // Highlight sphere
+    const hlGeo = new THREE.SphereGeometry(0.05, 16, 16)
+    const hlMat = new THREE.MeshBasicMaterial({ color: 0xff3333 })
+    const highlightMesh = new THREE.Mesh(hlGeo, hlMat)
+    highlightMesh.visible = false
+    scene.add(highlightMesh)
+
+    // Post-processing: bloom
+    const composer = new EffectComposer(renderer)
+    composer.addPass(new RenderPass(scene, camera))
+    const bloomPass = new UnrealBloomPass(new THREE.Vector2(w, h), 1.2, 0.5, 0.15)
+    composer.addPass(bloomPass)
+    composer.addPass(new OutputPass())
+
+    const raycaster = new THREE.Raycaster()
+    raycaster.params.Points!.threshold = 0.05
+
+    let animId = 0
+    const animate = () => {
+      animId = requestAnimationFrame(animate)
+      uniforms.uTime.value += 0.016
+      controls.update()
+      composer.render()
+    }
+    animate()
+
+    const ro = new ResizeObserver(() => {
+      const nw = mount.clientWidth
+      const nh = mount.clientHeight
+      renderer.setSize(nw, nh)
+      composer.setSize(nw, nh)
+      camera.aspect = nw / nh
+      camera.updateProjectionMatrix()
+    })
+    ro.observe(mount)
+
+    // Raycasting needs the raw renderer canvas for picking (composer renders to canvas)
+    sceneRef.current = { renderer, camera, controls, scene, pointsMesh, highlightMesh, raycaster, animId, composer, uniforms }
+
+    return () => {
+      cancelAnimationFrame(animId)
+      controls.dispose()
+      composer.dispose()
+      renderer.dispose()
+      ro.disconnect()
+      if (mount.contains(renderer.domElement)) mount.removeChild(renderer.domElement)
+    }
+  }, [points])
+
+  useEffect(() => {
+    const s = sceneRef.current
+    if (!s) return
+    const normalized = normalizedRef.current
+    if (highlightPosition !== null && normalized.length > 0) {
+      const a = Math.max(0, Math.floor(highlightPosition))
+      const b = Math.min(normalized.length - 1, Math.ceil(highlightPosition))
+      const t = highlightPosition - a
+      const pa = normalized[a], pb = normalized[b]
+      s.highlightMesh.position.set(
+        pa[0] + (pb[0] - pa[0]) * t,
+        pa[1] + (pb[1] - pa[1]) * t,
+        pa[2] + (pb[2] - pa[2]) * t,
+      )
+      s.highlightMesh.visible = true
+    } else {
+      s.highlightMesh.visible = false
+    }
+  }, [highlightPosition])
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    const s = sceneRef.current
+    if (!s) return
+    const rect = mountRef.current!.getBoundingClientRect()
+    const mouse = new THREE.Vector2(
+      ((e.clientX - rect.left) / rect.width) * 2 - 1,
+      -((e.clientY - rect.top) / rect.height) * 2 + 1
+    )
+    s.raycaster.setFromCamera(mouse, s.camera)
+    const hits = s.raycaster.intersectObject(s.pointsMesh)
+    if (hits.length > 0) {
+      setTooltip({ x: e.clientX - rect.left, y: e.clientY - rect.top, text: labels[hits[0].index!] })
+    } else {
+      setTooltip(null)
+    }
+  }
+
+  const mouseDownRef = useRef<{ x: number; y: number } | null>(null)
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => { mouseDownRef.current = { x: e.clientX, y: e.clientY } }
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const down = mouseDownRef.current
+    if (!down) return
+    const dx = e.clientX - down.x, dy = e.clientY - down.y
+    if (dx * dx + dy * dy > 25) return
+    const s = sceneRef.current
+    if (!s) return
+    const rect = mountRef.current!.getBoundingClientRect()
+    const mouse = new THREE.Vector2(
+      ((e.clientX - rect.left) / rect.width) * 2 - 1,
+      -((e.clientY - rect.top) / rect.height) * 2 + 1
+    )
+    s.raycaster.setFromCamera(mouse, s.camera)
+    const hits = s.raycaster.intersectObject(s.pointsMesh)
+    if (hits.length > 0) onPointClick(hits[0].index!)
+  }
+
+  return (
+    <div className="scatter-wrap" ref={mountRef} onMouseMove={handleMouseMove} onMouseDown={handleMouseDown} onClick={handleClick}>
+      {tooltip && (
+        <div className="scatter-tooltip" style={{ left: tooltip.x + 12, top: tooltip.y + 12 }}>
+          {tooltip.text}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/TranscriptViewer.tsx
+++ b/src/TranscriptViewer.tsx
@@ -89,9 +89,15 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
       if (position >= 1) setPosition(0)
       startTimeRef.current = null
       setIsPlaying(true)
-      rafRef.current = requestAnimationFrame(tick)
+      // When an external time source (e.g. YouTube player) is active, don't run
+      // the internal RAF — externalPosition updates will drive the cursor instead.
+      // Without this guard, the cursor drifts forward during pre-speech video intros
+      // where externalPosition is stuck at 0 and never triggers its cancel-RAF effect.
+      if (externalPlaying === undefined) {
+        rafRef.current = requestAnimationFrame(tick)
+      }
     }
-  }, [isPlaying, position, stopPlayback, tick])
+  }, [isPlaying, position, externalPlaying, stopPlayback, tick])
 
   // Restart RAF when tick changes (duration changes while playing)
   useEffect(() => {
@@ -130,7 +136,8 @@ export default function TranscriptViewer({ initialText, initialDuration, onWindo
       if (position >= 1) setPosition(0)
       startTimeRef.current = null
       setIsPlaying(true)
-      rafRef.current = requestAnimationFrame(tick)
+      // Don't start internal RAF — externalPosition updates drive the cursor
+      // when an external time source is active (same reasoning as handlePlayPause)
     } else if (!externalPlaying && isPlaying) {
       stopPlayback()
     }


### PR DESCRIPTION
## Summary

- **ScatterPlot3DV5**: CatmullRomCurve3 tube path with Cividis colormap, alternating brightness between node segments to show spacing
- **ScatterPlot3DV6**: Custom GLSL shader with per-point pulsing animation, UnrealBloom post-processing, vivid blue→cyan→yellow palette, and dense fill particles along the path
- **EmbeddingLayoutViewV5**: 3-way renderer picker (Points+Line / Cividis Tube / Glow Shader), persisted to localStorage
- **3-state camera follow button** (◎ Static / ◉ Tracking / ⬤ Following) across all renderers — Following mode rotates the orbital offset with the path tangent each frame so the view continuously re-aligns behind the cursor as the path curves, while still allowing free orbit/zoom
- **Smooth cursor sphere** via RAF lerp (0.2/frame) instead of direct position snap — eliminates jumpiness from discrete React state updates
- **Fix: cursor no longer drifts during pre-speech video intros** — internal RAF is not started when an external time source (YouTube) is active

## Test plan

- [ ] Navigate to `#v5`, load a transcript, run embedding
- [ ] Confirm tube renders with Cividis gradient and alternating brightness stripes
- [ ] Switch renderer picker between all 3 options
- [ ] Play video, confirm cursor sphere moves smoothly
- [ ] Enable Tracking — cursor stays centered, orbit works
- [ ] Enable Following — camera snaps behind cursor, re-aligns as cursor moves along path, orbit still works
- [ ] Confirm `#v4` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)