### PR TITLE
Responsive layout: landscape two-column + desktop split view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- v7 landscape layout: at 640px+ screen width (mobile landscape), the main panel splits into two columns — video on the left, full tab section (Raw, Windowed, Segments, 3D) on the right
+
 - Store embedding model ID and segment count alongside cached 3D points in localStorage — displayed as a small info overlay in the bottom-right corner of the scatter plot
 - Rename "Reset Viz" to "Rerun Viz" in v7 — clicking it shows the model selector and Visualize button with an ✕ to return to the visualization without re-embedding; the prior scatter plot remains visible throughout
 - Keep prior scatter plot visible while a new embedding runs or is cancelled — cancelling mid-progress restores the previous visualization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- v7 landscape layout: at 640px+ screen width (mobile landscape), the main panel splits into two columns — video on the left, full tab section (Raw, Windowed, Segments, 3D) on the right
+- v7 desktop layout: at 1024px+ width, the layout splits into a top row (video | 3D plot) and a bottom panel (Raw/Windowed/Segments transcript tabs); landscape mobile (640px–1023px) keeps the existing two-column layout with all tabs on the right
 
 - Store embedding model ID and segment count alongside cached 3D points in localStorage — displayed as a small info overlay in the bottom-right corner of the scatter plot
 - Rename "Reset Viz" to "Rerun Viz" in v7 — clicking it shows the model selector and Visualize button with an ✕ to return to the visualization without re-embedding; the prior scatter plot remains visible throughout

--- a/src/EmbeddingLayoutViewV7.tsx
+++ b/src/EmbeddingLayoutViewV7.tsx
@@ -370,7 +370,8 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
 
       {/* Main panel */}
       <div className="flex flex-1 min-h-0 overflow-hidden">
-        <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
+        <div className="flex-1 min-w-0 flex flex-col sm:flex-row overflow-hidden">
+          <div className="flex-shrink-0 sm:w-1/2 sm:overflow-hidden">
           {currentVideoId ? (
             <div className="relative flex-shrink-0">
               <div style={{ visibility: videoHidden ? 'hidden' : 'visible' }}>
@@ -399,6 +400,8 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
               </div>
             </div>
           )}
+          </div>
+          <div className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
           <TranscriptViewer
             key={`${loadedVideoId ?? 'empty'}-${loadCount}`}
             initialText={loadedText ?? undefined}
@@ -469,6 +472,7 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
               </button>
             }
           />
+          </div>
         </div>
 
       </div>

--- a/src/EmbeddingLayoutViewV7.tsx
+++ b/src/EmbeddingLayoutViewV7.tsx
@@ -433,7 +433,7 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
             {rendererType === 'cividis-tube' && <ScatterPlot3DV5 points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
             {rendererType === 'glow' && <ScatterPlot3DV6 points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
             {displayMeta && (
-              <div className="absolute bottom-2 right-2 text-[11px] text-right pointer-events-none leading-tight select-none" style={{ color: '#ccc', textShadow: '0 0 6px rgba(0,0,0,1), 0 0 6px rgba(0,0,0,1)' }}>
+              <div className="absolute bottom-2 right-2 text-[11px] text-right pointer-events-none leading-tight select-none rounded px-1.5 py-1" style={{ background: 'rgba(0,0,0,0.45)', color: 'rgba(255,255,255,0.75)' }}>
                 <div>{EMBEDDING_MODELS.find(m => m.id === displayMeta.modelId)?.label ?? displayMeta.modelId.split('/').pop()}</div>
                 <div>{displayMeta.segmentCount} segments</div>
               </div>

--- a/src/EmbeddingLayoutViewV7.tsx
+++ b/src/EmbeddingLayoutViewV7.tsx
@@ -393,6 +393,7 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
                 onPlayStateChange={videoHidden ? undefined : setYtPlaying}
                 playbackRate={playbackRate}
                 onVideoDuration={setVideoDuration}
+                noBottomMargin={isDesktop}
               />
             </div>
             {videoHidden && (

--- a/src/EmbeddingLayoutViewV7.tsx
+++ b/src/EmbeddingLayoutViewV7.tsx
@@ -481,8 +481,12 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
                 <div className="w-1/2 flex-shrink-0 overflow-hidden">
                   {videoBlock}
                 </div>
-                <div className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden border-l border-border">
-                  {threeDContent}
+                <div className="w-1/2 flex-shrink-0 overflow-hidden border-l border-border">
+                  <div className="relative w-full aspect-video">
+                    <div className="absolute inset-0 flex flex-col">
+                      {threeDContent}
+                    </div>
+                  </div>
                 </div>
               </div>
               {/* Desktop: bottom row — transcript tabs (Raw/Windowed/Segments) */}

--- a/src/EmbeddingLayoutViewV7.tsx
+++ b/src/EmbeddingLayoutViewV7.tsx
@@ -476,8 +476,8 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
         if (isDesktop) {
           return (
             <>
-              {/* Desktop: top row — video left, 3D right */}
-              <div className="flex flex-1 min-h-0 overflow-hidden">
+              {/* Desktop: top row — video left, 3D right; height driven by aspect-video content */}
+              <div className="flex flex-shrink-0 overflow-hidden">
                 <div className="w-1/2 flex-shrink-0 overflow-hidden">
                   {videoBlock}
                 </div>
@@ -490,7 +490,7 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
                 </div>
               </div>
               {/* Desktop: bottom row — transcript tabs (Raw/Windowed/Segments) */}
-              <div className="flex-shrink-0 h-[38vh] border-t border-border flex flex-col overflow-hidden">
+              <div className="flex-1 min-h-0 border-t border-border flex flex-col overflow-hidden">
                 <TranscriptViewer
                   key={transcriptKey}
                   {...transcriptViewerProps}

--- a/src/EmbeddingLayoutViewV7.tsx
+++ b/src/EmbeddingLayoutViewV7.tsx
@@ -433,7 +433,7 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
             {rendererType === 'cividis-tube' && <ScatterPlot3DV5 points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
             {rendererType === 'glow' && <ScatterPlot3DV6 points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
             {displayMeta && (
-              <div className="absolute bottom-2 right-2 text-[11px] text-text opacity-40 text-right pointer-events-none leading-tight select-none">
+              <div className="absolute bottom-2 right-2 text-[11px] text-right pointer-events-none leading-tight select-none" style={{ color: '#ccc', textShadow: '0 0 6px rgba(0,0,0,1), 0 0 6px rgba(0,0,0,1)' }}>
                 <div>{EMBEDDING_MODELS.find(m => m.id === displayMeta.modelId)?.label ?? displayMeta.modelId.split('/').pop()}</div>
                 <div>{displayMeta.segmentCount} segments</div>
               </div>

--- a/src/EmbeddingLayoutViewV7.tsx
+++ b/src/EmbeddingLayoutViewV7.tsx
@@ -321,6 +321,18 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
     else dialog.close()
   }, [infoOpen])
 
+  const [isDesktop, setIsDesktop] = useState(() => window.matchMedia('(min-width: 1024px)').matches)
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 1024px)')
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+  // When switching to desktop, the '3d' tab doesn't exist in the bottom TranscriptViewer
+  useEffect(() => {
+    if (isDesktop && transcriptTab === '3d') setTranscriptTab('windowed')
+  }, [isDesktop]) // eslint-disable-line react-hooks/exhaustive-deps
+
   return (
     <div className="flex flex-col h-[100dvh] overflow-hidden overscroll-none">
       {/* Info modal */}
@@ -368,114 +380,147 @@ const isEmbedding = embedPhase.status === 'model-loading' || embedPhase.status =
         {loadStatus === 'error' && <p className="text-[13px] text-[#e53e3e] m-0">{loadError}</p>}
       </div>
 
-      {/* Main panel */}
-      <div className="flex flex-1 min-h-0 overflow-hidden">
-        <div className="flex-1 min-w-0 flex flex-col sm:flex-row overflow-hidden">
-          <div className="flex-shrink-0 sm:w-1/2 sm:overflow-hidden">
-          {currentVideoId ? (
-            <div className="relative flex-shrink-0">
-              <div style={{ visibility: videoHidden ? 'hidden' : 'visible' }}>
-                <YoutubePlayerEmbed
-                  videoId={currentVideoId}
-                  onTimeUpdate={setVideoTime}
-                  seekTo={videoHidden ? undefined : seekTarget}
-                  playing={videoHidden ? false : transcriptPlaying}
-                  onPlayStateChange={videoHidden ? undefined : setYtPlaying}
-                  playbackRate={playbackRate}
-                  onVideoDuration={setVideoDuration}
+      {/* Shared content blocks */}
+      {(() => {
+        const videoBlock = currentVideoId ? (
+          <div className="relative flex-shrink-0">
+            <div style={{ visibility: videoHidden ? 'hidden' : 'visible' }}>
+              <YoutubePlayerEmbed
+                videoId={currentVideoId}
+                onTimeUpdate={setVideoTime}
+                seekTo={videoHidden ? undefined : seekTarget}
+                playing={videoHidden ? false : transcriptPlaying}
+                onPlayStateChange={videoHidden ? undefined : setYtPlaying}
+                playbackRate={playbackRate}
+                onVideoDuration={setVideoDuration}
+              />
+            </div>
+            {videoHidden && (
+              <div className="absolute inset-0 w-full max-w-[640px] mx-auto">
+                <div className="yt-player-aspect relative w-full aspect-video bg-code-bg rounded flex items-center justify-center">
+                  <span className="text-text opacity-40 text-[13px]">YouTube paused — playing faster than 2×</span>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="w-full max-w-[640px] mx-auto flex-shrink-0">
+            <div className="yt-player-aspect relative w-full aspect-video bg-code-bg rounded flex items-center justify-center">
+              <span className="text-text opacity-40 text-[13px]">Paste a YouTube URL above to load the player</span>
+            </div>
+          </div>
+        )
+
+        const segmentsContent = segments && segments.length > 0 ? (
+          <ul className="list-none p-0 m-0 overflow-y-auto overscroll-y-contain flex-1">
+            {segments.map((seg, i) => (
+              <li key={i} className="flex gap-2 py-2 px-3.5 border-b border-border text-[13px] items-start">
+                <span className="text-text opacity-50 min-w-[28px] flex-shrink-0 text-right tabular-nums pt-[1px]">{i + 1}</span>
+                <span className="text-text-h leading-[1.45]">{seg}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-text opacity-40 text-sm p-8 text-center">
+            Load a transcript to see segments.
+          </div>
+        )
+
+        const threeDContent = displayPoints !== null ? (
+          <div className="flex-1 min-h-0 flex flex-col overflow-hidden relative">
+            {rendererType === 'original' && <ScatterPlot3D points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
+            {rendererType === 'cividis-tube' && <ScatterPlot3DV5 points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
+            {rendererType === 'glow' && <ScatterPlot3DV6 points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
+            {displayMeta && (
+              <div className="absolute bottom-2 right-2 text-[11px] text-text opacity-40 text-right pointer-events-none leading-tight select-none">
+                <div>{EMBEDDING_MODELS.find(m => m.id === displayMeta.modelId)?.label ?? displayMeta.modelId.split('/').pop()}</div>
+                <div>{displayMeta.segmentCount} segments</div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex-1 flex items-center justify-center text-text opacity-40 text-sm p-8 text-center">
+            {isEmbedding ? 'Embedding in progress…' : 'Run Visualize to see segments in 3D.'}
+          </div>
+        )
+
+        const transcriptKey = `${loadedVideoId ?? 'empty'}-${loadCount}`
+        const transcriptViewerProps = {
+          initialText: loadedText ?? undefined,
+          initialDuration: loadedDuration ?? undefined,
+          onWindowChange: handleWindowChange,
+          onParamsBlur: handleParamsBlur,
+          onCursorChange: handleCursorChange,
+          externalPosition: (videoHidden ? undefined : externalPosition) ?? clickSeekPosition,
+          externalPlaying: videoHidden ? undefined : ytPlaying,
+          onScrub: handleScrub,
+          onPlayingChange: setTranscriptPlaying,
+          onSpeedChange: setPlaybackRate,
+          hideSegmentsMode: true,
+          onSubtitleLoad: handleSubtitleLoad,
+          hideFileLoad: !isProd,
+          tab: transcriptTab,
+          onTabChange: setTranscriptTab,
+          warning: durationMismatch ? `⚠ Transcript duration (${totalSecs}s) doesn't match video (${Math.round(videoDuration!)}s) — transcript may be out of date.` : undefined,
+          prependTextareaButtons: (
+            <button
+              className="flex-shrink-0 py-1.5 px-3 rounded-md border-0 bg-accent text-white text-[13px] font-medium cursor-pointer whitespace-nowrap transition-opacity duration-150 hover:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed"
+              onClick={isProd ? () => window.open(transcriptToolUrl, '_blank') : handleLoad}
+              disabled={isProd ? !currentVideoId : loadStatus === 'loading'}
+            >
+              {!isProd && loadStatus === 'loading' ? 'Loading…' : `Fetch${isProd ? ' ↗' : ''}`}
+            </button>
+          ),
+        }
+
+        if (isDesktop) {
+          return (
+            <>
+              {/* Desktop: top row — video left, 3D right */}
+              <div className="flex flex-1 min-h-0 overflow-hidden">
+                <div className="w-1/2 flex-shrink-0 overflow-hidden">
+                  {videoBlock}
+                </div>
+                <div className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden border-l border-border">
+                  {threeDContent}
+                </div>
+              </div>
+              {/* Desktop: bottom row — transcript tabs (Raw/Windowed/Segments) */}
+              <div className="flex-shrink-0 h-[38vh] border-t border-border flex flex-col overflow-hidden">
+                <TranscriptViewer
+                  key={transcriptKey}
+                  {...transcriptViewerProps}
+                  tab={transcriptTab === '3d' ? 'windowed' : transcriptTab}
+                  extraTabs={[{ id: 'segments', label: 'Segments' }]}
+                  extraTabContent={segmentsContent}
                 />
               </div>
-              {videoHidden && (
-                <div className="absolute inset-0 w-full max-w-[640px] mx-auto">
-                  <div className="yt-player-aspect relative w-full aspect-video bg-code-bg rounded flex items-center justify-center">
-                    <span className="text-text opacity-40 text-[13px]">YouTube paused — playing faster than 2×</span>
-                  </div>
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="w-full max-w-[640px] mx-auto flex-shrink-0">
-              <div className="yt-player-aspect relative w-full aspect-video bg-code-bg rounded flex items-center justify-center">
-                <span className="text-text opacity-40 text-[13px]">Paste a YouTube URL above to load the player</span>
+            </>
+          )
+        }
+
+        return (
+          /* Mobile/landscape: single flex column, splits to two columns at sm: */
+          <div className="flex flex-1 min-h-0 overflow-hidden">
+            <div className="flex-1 min-w-0 flex flex-col sm:flex-row overflow-hidden">
+              <div className="flex-shrink-0 sm:w-1/2 sm:overflow-hidden">
+                {videoBlock}
+              </div>
+              <div className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
+                <TranscriptViewer
+                  key={transcriptKey}
+                  {...transcriptViewerProps}
+                  extraTabs={[
+                    { id: 'segments', label: 'Segments' },
+                    { id: '3d', label: '3D' },
+                  ]}
+                  extraTabContent={transcriptTab === 'segments' ? segmentsContent : threeDContent}
+                />
               </div>
             </div>
-          )}
           </div>
-          <div className="flex-1 min-h-0 min-w-0 flex flex-col overflow-hidden">
-          <TranscriptViewer
-            key={`${loadedVideoId ?? 'empty'}-${loadCount}`}
-            initialText={loadedText ?? undefined}
-            initialDuration={loadedDuration ?? undefined}
-            onWindowChange={handleWindowChange}
-            onParamsBlur={handleParamsBlur}
-            onCursorChange={handleCursorChange}
-            externalPosition={(videoHidden ? undefined : externalPosition) ?? clickSeekPosition}
-            externalPlaying={videoHidden ? undefined : ytPlaying}
-            onScrub={handleScrub}
-            onPlayingChange={setTranscriptPlaying}
-            onSpeedChange={setPlaybackRate}
-            hideSegmentsMode
-            onSubtitleLoad={handleSubtitleLoad}
-            hideFileLoad={!isProd}
-            tab={transcriptTab}
-            onTabChange={setTranscriptTab}
-            warning={durationMismatch ? `⚠ Transcript duration (${totalSecs}s) doesn't match video (${Math.round(videoDuration!)}s) — transcript may be out of date.` : undefined}
-            extraTabs={[
-              { id: 'segments', label: 'Segments' },
-              { id: '3d', label: '3D' },
-            ]}
-            extraTabContent={
-              transcriptTab === 'segments' ? (
-                segments && segments.length > 0 ? (
-                  <ul className="list-none p-0 m-0 overflow-y-auto overscroll-y-contain flex-1">
-                    {segments.map((seg, i) => (
-                      <li key={i} className="flex gap-2 py-2 px-3.5 border-b border-border text-[13px] items-start">
-                        <span className="text-text opacity-50 min-w-[28px] flex-shrink-0 text-right tabular-nums pt-[1px]">{i + 1}</span>
-                        <span className="text-text-h leading-[1.45]">{seg}</span>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <div className="flex-1 flex items-center justify-center text-text opacity-40 text-sm p-8 text-center">
-                    Load a transcript to see segments.
-                  </div>
-                )
-              ) : (
-                displayPoints !== null ? (
-                  <div className="flex-1 min-h-0 flex flex-col overflow-hidden relative">
-                    {/* eslint-disable react-hooks/refs */}
-                    {rendererType === 'original' && <ScatterPlot3D points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
-                    {rendererType === 'cividis-tube' && <ScatterPlot3DV5 points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
-                    {rendererType === 'glow' && <ScatterPlot3DV6 points={displayPoints} labels={segments ?? []} highlightPosition={highlightIndex} onPointClick={handlePointClick} initialCameraState={cameraStateRef.current ?? undefined} onCameraChange={s => { cameraStateRef.current = s }} />}
-                    {/* eslint-enable react-hooks/refs */}
-                    {displayMeta && (
-                      <div className="absolute bottom-2 right-2 text-[11px] text-text opacity-40 text-right pointer-events-none leading-tight select-none">
-                        <div>{EMBEDDING_MODELS.find(m => m.id === displayMeta.modelId)?.label ?? displayMeta.modelId.split('/').pop()}</div>
-                        <div>{displayMeta.segmentCount} segments</div>
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <div className="flex-1 flex items-center justify-center text-text opacity-40 text-sm p-8 text-center">
-                    {isEmbedding ? 'Embedding in progress…' : 'Run Visualize to see segments in 3D.'}
-                  </div>
-                )
-              )
-            }
-            prependTextareaButtons={
-              <button
-                className="flex-shrink-0 py-1.5 px-3 rounded-md border-0 bg-accent text-white text-[13px] font-medium cursor-pointer whitespace-nowrap transition-opacity duration-150 hover:opacity-85 disabled:opacity-50 disabled:cursor-not-allowed"
-                onClick={isProd ? () => window.open(transcriptToolUrl, '_blank') : handleLoad}
-                disabled={isProd ? !currentVideoId : loadStatus === 'loading'}
-              >
-                {!isProd && loadStatus === 'loading' ? 'Loading…' : `Fetch${isProd ? ' ↗' : ''}`}
-              </button>
-            }
-          />
-          </div>
-        </div>
-
-      </div>
+        )
+      })()}
 
       {/* Bottom: embedding form */}
       <div className="flex-shrink-0 border-t border-border px-4 py-2.5 flex flex-col gap-2">

--- a/src/YoutubePlayerEmbed.tsx
+++ b/src/YoutubePlayerEmbed.tsx
@@ -15,9 +15,10 @@ interface YoutubePlayerEmbedProps {
   onPlayStateChange?: (playing: boolean) => void
   playbackRate?: number
   onVideoDuration?: (secs: number) => void
+  noBottomMargin?: boolean
 }
 
-export default function YoutubePlayerEmbed({ videoId, onTimeUpdate, seekTo, playing, onPlayStateChange, playbackRate, onVideoDuration }: YoutubePlayerEmbedProps) {
+export default function YoutubePlayerEmbed({ videoId, onTimeUpdate, seekTo, playing, onPlayStateChange, playbackRate, onVideoDuration, noBottomMargin }: YoutubePlayerEmbedProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const playerRef = useRef<YT.Player | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -153,7 +154,7 @@ export default function YoutubePlayerEmbed({ videoId, onTimeUpdate, seekTo, play
   }, [playbackRate])
 
   return (
-    <div className="w-full max-w-[640px] mx-auto mb-4">
+    <div className={`w-full max-w-[640px] mx-auto${noBottomMargin ? '' : ' mb-4'}`}>
       <div className="yt-player-aspect relative w-full aspect-video">
         <div ref={containerRef} />
       </div>


### PR DESCRIPTION
## Summary

- **Portrait mobile** (<640px): unchanged single-column layout
- **Landscape mobile** (640–1023px): two columns — video left, all tabs (Raw/Windowed/Segments/3D) right
- **Desktop** (1024px+): top row with video + 3D plot side-by-side (both 16:9, same height), bottom panel with Raw/Windowed/Segments transcript tabs filling remaining space

## Details

- Top row height is driven by `aspect-video` content — no excess space
- `YoutubePlayerEmbed` gains `noBottomMargin` prop used in desktop layout
- 3D plot model info overlay uses a dark pill background for legibility on both light and dark backgrounds
- On desktop, auto-switches away from the '3d' tab in the bottom panel (since 3D is always visible in the top row)

## Test plan

- [ ] Portrait mobile (~390px): single column unchanged
- [ ] Landscape mobile (~844px): video left, tabs right, 3D tab works
- [ ] Desktop (>1024px): video and 3D plot same height top row; Raw/Windowed/Segments in bottom panel
- [ ] Model info overlay readable on both dark (WebGL canvas) and light backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)