### PR TITLE
Add #manual branching embedding projector view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Preserve camera position when switching renderers in `#manual` view — camera state is stored in a ref and passed as `initialCameraState` to each renderer on mount
+
+- Make Glow renderer adaptive to canvas size and zoom: particle sizes scale with canvas height (`uScale` uniform), fill density increased (12→20 particles per segment), and bloom strength/radius update each frame based on camera distance so the glow stays visible when zoomed out or viewing full-screen
+
 - Add `#manual` view: type lines of text into a textarea — each line becomes one embedding node; prefix with `- ` to start a new branch, indent to continue it; branches appear as distinct colored paths in the 3D scatter plot, each visually continuing from the branching point; renderer toggle (Points / Tube / Glow) matches the styles available in other embedding views
 
 - v7 desktop layout: at 1024px+ width, the layout splits into a top row (video | 3D plot) and a bottom panel (Raw/Windowed/Segments transcript tabs); landscape mobile (640px–1023px) keeps the existing two-column layout with all tabs on the right

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add `#manual` view: type lines of text into a textarea — each line becomes one embedding node; prefix with `- ` to start a new branch, indent to continue it; branches appear as distinct colored paths in the 3D scatter plot with connector lines back to the last root node
+- Add `#manual` view: type lines of text into a textarea — each line becomes one embedding node; prefix with `- ` to start a new branch, indent to continue it; branches appear as distinct colored paths in the 3D scatter plot, each visually continuing from the branching point; renderer toggle (Points / Tube / Glow) matches the styles available in other embedding views
 
 - v7 desktop layout: at 1024px+ width, the layout splits into a top row (video | 3D plot) and a bottom panel (Raw/Windowed/Segments transcript tabs); landscape mobile (640px–1023px) keeps the existing two-column layout with all tabs on the right
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `#manual` view: type lines of text into a textarea — each line becomes one embedding node; prefix with `- ` to start a new branch, indent to continue it; branches appear as distinct colored paths in the 3D scatter plot with connector lines back to the last root node
+
 - v7 desktop layout: at 1024px+ width, the layout splits into a top row (video | 3D plot) and a bottom panel (Raw/Windowed/Segments transcript tabs); landscape mobile (640px–1023px) keeps the existing two-column layout with all tabs on the right
 
 - Store embedding model ID and segment count alongside cached 3D points in localStorage — displayed as a small info overlay in the bottom-right corner of the scatter plot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add Share button to `#manual` view — compresses textarea text with pako into a `?share=` query param and copies the URL to clipboard; loading a share URL restores the text automatically
+
 - Preserve camera position when switching renderers in `#manual` view — camera state is stored in a ref and passed as `initialCameraState` to each renderer on mount
 
 - Make Glow renderer adaptive to canvas size and zoom: particle sizes scale with canvas height (`uScale` uniform), fill density increased (12→20 particles per segment), and bloom strength/radius update each frame based on camera distance so the glow stays visible when zoomed out or viewing full-screen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Default renderer in `#manual` changed to Glow; default embedding model changed to MiniLM-L12 (balanced)
+- Share button in `#manual` gains an "auto-embed" checkbox — when checked, the shared URL triggers embedding automatically on load
+
 - Add Share button to `#manual` view — compresses textarea text with pako into a `?share=` query param and copies the URL to clipboard; loading a share URL restores the text automatically
 
 - Preserve camera position when switching renderers in `#manual` view — camera state is stored in a ref and passed as `initialCameraState` to each renderer on mount

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import EmbeddingLayoutView from './EmbeddingLayoutView'
 import EmbeddingLayoutViewV5 from './EmbeddingLayoutViewV5'
 import EmbeddingLayoutViewV7 from './EmbeddingLayoutViewV7'
 import MicTranscriptViewer from './MicTranscriptViewer'
+import ManualEmbeddingProjector from './ManualEmbeddingProjector'
 
 function useHash() {
   const [hash, setHash] = useState(window.location.hash)
@@ -68,6 +69,12 @@ function IndexPage() {
               <span className="text-sm text-text">Mobile-optimized version of v5. (default)</span>
             </a>
           </li>
+          <li>
+            <a href="#manual" className="flex flex-col gap-1 py-4 px-5 border border-border rounded-lg no-underline text-text-h bg-social-bg transition-[box-shadow,border-color] duration-200 hover:shadow-[var(--shadow)] hover:border-accent-border">
+              <strong className="text-base">Manual Branching Projector</strong>
+              <span className="text-sm text-text">Type or paste lines of text — each line becomes an embedding node; use bullet syntax to create branches visualized in 3D.</span>
+            </a>
+          </li>
         </ul>
       </section>
       <div className="ticks"></div>
@@ -127,6 +134,7 @@ function App() {
   if (hash === '#v5') return <><GitHubCorner /><IndexLink /><EmbeddingLayoutViewV5 /></>
   if (hash === '#v6') return <><GitHubCorner /><IndexLink /><MicTranscriptViewer /></>
   if (hash === '#v7') return <><GitHubCorner /><EmbeddingLayoutViewV7 /></>
+  if (hash === '#manual') return <><GitHubCorner /><IndexLink /><ManualEmbeddingProjector /></>
   if (hash === '#index') return <><GitHubCorner /><IndexPage /></>
   return <><GitHubCorner /><EmbeddingLayoutViewV7 /></>
 }

--- a/src/ManualEmbeddingProjector.tsx
+++ b/src/ManualEmbeddingProjector.tsx
@@ -1,9 +1,10 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef } from 'react'
 import { EMBEDDING_MODELS, type EmbeddingModelId } from './embedSegments'
 import { useEmbeddingWorker } from './useEmbeddingWorker'
 import ScatterPlot3D from './ScatterPlot3D'
 import ScatterPlot3DV5 from './ScatterPlot3DV5'
 import ScatterPlot3DV6 from './ScatterPlot3DV6'
+import type { CameraState } from './scatterTypes'
 
 type RendererType = 'original' | 'cividis-tube' | 'glow'
 
@@ -24,9 +25,8 @@ Why does a moon rock taste better than an Earth
 Why does a moon rock taste better than an Earth rock?
 Why does a moon rock taste better than an Earth rock? It's
 Why does a moon rock taste better than an Earth rock? It's a little
-- Why does a moon rock taste better than an Earth rock? It's a little meteor.
-  Why does a moon rock taste better than an Earth rock? It's a little meteor. (punchline)
-- Why does a moon rock taste better than an Earth rock? It's a little meatier.`
+- Why does a moon rock taste better than an Earth rock? It's a little meteor. [space]
+- Why does a moon rock taste better than an Earth rock? It's a little meatier. [taste]`
 
 interface ParsedSegment {
   text: string
@@ -63,6 +63,7 @@ export default function ManualEmbeddingProjector() {
   )
   const [submitted, setSubmitted] = useState<ParsedSegment[] | null>(null)
   const [rendererType, setRendererType] = useState<RendererType>('original')
+  const cameraStateRef = useRef<CameraState | undefined>(undefined)
   const { phase, runEmbedding, cancelEmbedding, resetPhase } = useEmbeddingWorker()
 
   const handleEmbed = () => {
@@ -173,6 +174,8 @@ export default function ManualEmbeddingProjector() {
               branchIds={branchIds ?? undefined}
               highlightPosition={null}
               onPointClick={() => {}}
+              initialCameraState={cameraStateRef.current}
+              onCameraChange={s => { cameraStateRef.current = s }}
             />
           )}
           {rendererType === 'cividis-tube' && (
@@ -182,6 +185,8 @@ export default function ManualEmbeddingProjector() {
               branchIds={branchIds ?? undefined}
               highlightPosition={null}
               onPointClick={() => {}}
+              initialCameraState={cameraStateRef.current}
+              onCameraChange={s => { cameraStateRef.current = s }}
             />
           )}
           {rendererType === 'glow' && (
@@ -191,6 +196,8 @@ export default function ManualEmbeddingProjector() {
               branchIds={branchIds ?? undefined}
               highlightPosition={null}
               onPointClick={() => {}}
+              initialCameraState={cameraStateRef.current}
+              onCameraChange={s => { cameraStateRef.current = s }}
             />
           )}
 

--- a/src/ManualEmbeddingProjector.tsx
+++ b/src/ManualEmbeddingProjector.tsx
@@ -2,6 +2,16 @@ import { useState, useMemo } from 'react'
 import { EMBEDDING_MODELS, type EmbeddingModelId } from './embedSegments'
 import { useEmbeddingWorker } from './useEmbeddingWorker'
 import ScatterPlot3D from './ScatterPlot3D'
+import ScatterPlot3DV5 from './ScatterPlot3DV5'
+import ScatterPlot3DV6 from './ScatterPlot3DV6'
+
+type RendererType = 'original' | 'cividis-tube' | 'glow'
+
+const RENDERER_LABELS: Record<RendererType, string> = {
+  'original':    'Points',
+  'cividis-tube': 'Tube',
+  'glow':        'Glow',
+}
 
 const EXAMPLE_INPUT = `Why
 Why does
@@ -52,6 +62,7 @@ export default function ManualEmbeddingProjector() {
     EMBEDDING_MODELS.find(m => m.default)!.id
   )
   const [submitted, setSubmitted] = useState<ParsedSegment[] | null>(null)
+  const [rendererType, setRendererType] = useState<RendererType>('original')
   const { phase, runEmbedding, cancelEmbedding, resetPhase } = useEmbeddingWorker()
 
   const handleEmbed = () => {
@@ -154,14 +165,50 @@ export default function ManualEmbeddingProjector() {
         </div>
       ) : (
         /* 3D scatter */
-        <div className="flex-1 min-h-0">
-          <ScatterPlot3D
-            points={phase.points}
-            labels={labels}
-            branchIds={branchIds ?? undefined}
-            highlightPosition={null}
-            onPointClick={() => {}}
-          />
+        <div className="flex-1 min-h-0 relative">
+          {rendererType === 'original' && (
+            <ScatterPlot3D
+              points={phase.points}
+              labels={labels}
+              branchIds={branchIds ?? undefined}
+              highlightPosition={null}
+              onPointClick={() => {}}
+            />
+          )}
+          {rendererType === 'cividis-tube' && (
+            <ScatterPlot3DV5
+              points={phase.points}
+              labels={labels}
+              highlightPosition={null}
+              onPointClick={() => {}}
+            />
+          )}
+          {rendererType === 'glow' && (
+            <ScatterPlot3DV6
+              points={phase.points}
+              labels={labels}
+              highlightPosition={null}
+              onPointClick={() => {}}
+            />
+          )}
+
+          {/* Renderer toggle */}
+          <div className="absolute top-2 right-2 flex gap-1 z-10 pointer-events-auto">
+            {(Object.keys(RENDERER_LABELS) as RendererType[]).map(r => (
+              <button
+                key={r}
+                className={[
+                  'text-[11px] py-[3px] px-2 rounded border cursor-pointer transition-[background,color,border-color] duration-150',
+                  r === rendererType
+                    ? 'bg-[rgba(40,100,200,0.35)] border-[rgba(80,140,255,0.6)] text-white'
+                    : 'bg-black/55 text-white/65 border-white/[0.18] hover:bg-black/75 hover:text-white',
+                ].join(' ')}
+                onClick={() => setRendererType(r)}
+              >
+                {RENDERER_LABELS[r]}
+              </button>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/src/ManualEmbeddingProjector.tsx
+++ b/src/ManualEmbeddingProjector.tsx
@@ -1,0 +1,169 @@
+import { useState, useMemo } from 'react'
+import { EMBEDDING_MODELS, type EmbeddingModelId } from './embedSegments'
+import { useEmbeddingWorker } from './useEmbeddingWorker'
+import ScatterPlot3D from './ScatterPlot3D'
+
+const EXAMPLE_INPUT = `Why
+Why does
+Why does a moon
+Why does a moon rock
+Why does a moon rock taste
+Why does a moon rock taste better
+Why does a moon rock taste better than
+Why does a moon rock taste better than an Earth
+Why does a moon rock taste better than an Earth rock?
+Why does a moon rock taste better than an Earth rock? It's
+Why does a moon rock taste better than an Earth rock? It's a little
+- Why does a moon rock taste better than an Earth rock? It's a little meteor.
+  Why does a moon rock taste better than an Earth rock? It's a little meteor. (punchline)
+- Why does a moon rock taste better than an Earth rock? It's a little meatier.`
+
+interface ParsedSegment {
+  text: string
+  branchId: number
+}
+
+function parseInput(raw: string): ParsedSegment[] {
+  const lines = raw.split('\n')
+  const segments: ParsedSegment[] = []
+  let currentBranchId = 0
+  let nextBranchId = 1
+
+  for (const line of lines) {
+    if (!line.trim()) continue
+
+    if (line.startsWith('- ')) {
+      currentBranchId = nextBranchId++
+      segments.push({ text: line.slice(2).trim(), branchId: currentBranchId })
+    } else if (/^\s/.test(line) && currentBranchId !== 0) {
+      segments.push({ text: line.trim(), branchId: currentBranchId })
+    } else {
+      currentBranchId = 0
+      segments.push({ text: line.trim(), branchId: 0 })
+    }
+  }
+
+  return segments
+}
+
+export default function ManualEmbeddingProjector() {
+  const [inputText, setInputText] = useState(EXAMPLE_INPUT)
+  const [selectedModel, setSelectedModel] = useState<EmbeddingModelId>(
+    EMBEDDING_MODELS.find(m => m.default)!.id
+  )
+  const [submitted, setSubmitted] = useState<ParsedSegment[] | null>(null)
+  const { phase, runEmbedding, cancelEmbedding, resetPhase } = useEmbeddingWorker()
+
+  const handleEmbed = () => {
+    const segments = parseInput(inputText)
+    if (segments.length < 2) return
+    setSubmitted(segments)
+    resetPhase()
+    runEmbedding(segments.map(s => s.text), selectedModel)
+  }
+
+  const handleReset = () => {
+    cancelEmbedding()
+    setSubmitted(null)
+  }
+
+  const branchIds = useMemo(
+    () => submitted?.map(s => s.branchId) ?? null,
+    [submitted]
+  )
+
+  const labels = useMemo(
+    () => submitted?.map(s => s.text) ?? [],
+    [submitted]
+  )
+
+  const isRunning = phase.status === 'model-loading' || phase.status === 'embedding' || phase.status === 'umap-running'
+  const isDone = phase.status === 'done'
+
+  return (
+    <div className="flex flex-col h-screen bg-[var(--bg)] text-[var(--text)] overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--border)] shrink-0">
+        <h2 className="text-sm font-semibold m-0 grow">Manual Branching Projector</h2>
+        {isDone && (
+          <button
+            className="text-xs px-2 py-1 rounded border border-[var(--border)] opacity-60 hover:opacity-100 transition-opacity"
+            onClick={handleReset}
+          >
+            ← Edit input
+          </button>
+        )}
+      </div>
+
+      {!isDone ? (
+        /* Input panel */
+        <div className="flex flex-col gap-3 p-4 max-w-2xl w-full mx-auto mt-4">
+          <p className="text-xs opacity-60 m-0">
+            Each line = one embedding node. Use <code className="bg-[rgba(255,255,255,0.08)] px-1 rounded">- </code> to start a new branch; indent with spaces to continue it.
+          </p>
+          <textarea
+            className="w-full font-mono text-sm rounded border border-[var(--border)] bg-[rgba(255,255,255,0.04)] p-3 resize-y min-h-[220px] focus:outline-none focus:border-[var(--accent-border)]"
+            value={inputText}
+            onChange={e => setInputText(e.target.value)}
+            spellCheck={false}
+            disabled={isRunning}
+          />
+
+          <div className="flex items-center gap-3">
+            <select
+              className="text-xs rounded border border-[var(--border)] bg-[rgba(255,255,255,0.06)] px-2 py-1 grow focus:outline-none"
+              value={selectedModel}
+              onChange={e => setSelectedModel(e.target.value as EmbeddingModelId)}
+              disabled={isRunning}
+            >
+              {EMBEDDING_MODELS.map(m => (
+                <option key={m.id} value={m.id}>{m.label}</option>
+              ))}
+            </select>
+
+            {!isRunning ? (
+              <button
+                className="text-xs px-3 py-1.5 rounded border border-[var(--accent-border)] bg-[rgba(80,140,255,0.15)] hover:bg-[rgba(80,140,255,0.3)] transition-colors shrink-0"
+                onClick={handleEmbed}
+              >
+                Embed
+              </button>
+            ) : (
+              <button
+                className="text-xs px-3 py-1.5 rounded border border-[var(--border)] opacity-70 hover:opacity-100 transition-opacity shrink-0"
+                onClick={handleReset}
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+
+          {/* Progress */}
+          {phase.status === 'model-loading' && (
+            <p className="text-xs opacity-60 m-0">Loading model… {phase.progress}%</p>
+          )}
+          {phase.status === 'embedding' && (
+            <p className="text-xs opacity-60 m-0">Embedding {phase.loaded}/{phase.total}…</p>
+          )}
+          {phase.status === 'umap-running' && (
+            <p className="text-xs opacity-60 m-0">Running UMAP…</p>
+          )}
+          {phase.status === 'error' && (
+            <p className="text-xs text-red-400 m-0">Error: {phase.message}</p>
+          )}
+        </div>
+      ) : (
+        /* 3D scatter */
+        <div className="flex-1 min-h-0">
+          <ScatterPlot3D
+            points={phase.points}
+            labels={labels}
+            branchIds={branchIds ?? undefined}
+            highlightPosition={null}
+            onPointClick={() => {}}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ManualEmbeddingProjector.tsx
+++ b/src/ManualEmbeddingProjector.tsx
@@ -179,6 +179,7 @@ export default function ManualEmbeddingProjector() {
             <ScatterPlot3DV5
               points={phase.points}
               labels={labels}
+              branchIds={branchIds ?? undefined}
               highlightPosition={null}
               onPointClick={() => {}}
             />
@@ -187,6 +188,7 @@ export default function ManualEmbeddingProjector() {
             <ScatterPlot3DV6
               points={phase.points}
               labels={labels}
+              branchIds={branchIds ?? undefined}
               highlightPosition={null}
               onPointClick={() => {}}
             />

--- a/src/ManualEmbeddingProjector.tsx
+++ b/src/ManualEmbeddingProjector.tsx
@@ -5,6 +5,7 @@ import ScatterPlot3D from './ScatterPlot3D'
 import ScatterPlot3DV5 from './ScatterPlot3DV5'
 import ScatterPlot3DV6 from './ScatterPlot3DV6'
 import type { CameraState } from './scatterTypes'
+import { buildShareUrl, readShareParam } from './shareUrl'
 
 type RendererType = 'original' | 'cividis-tube' | 'glow'
 
@@ -62,7 +63,8 @@ function parseInput(raw: string): ParsedSegment[] {
 }
 
 export default function ManualEmbeddingProjector() {
-  const [inputText, setInputText] = useState(EXAMPLE_INPUT)
+  const [inputText, setInputText] = useState(() => readShareParam()?.manualText ?? EXAMPLE_INPUT)
+  const [copyLabel, setCopyLabel] = useState<'Share' | 'Copied!'>('Share')
   const [selectedModel, setSelectedModel] = useState<EmbeddingModelId>(
     EMBEDDING_MODELS.find(m => m.default)!.id
   )
@@ -82,6 +84,14 @@ export default function ManualEmbeddingProjector() {
   const handleReset = () => {
     cancelEmbedding()
     setSubmitted(null)
+  }
+
+  const handleShare = () => {
+    const url = buildShareUrl({ windowSize: 0, overlapPct: 0, manualText: inputText }, '#manual')
+    navigator.clipboard.writeText(url).then(() => {
+      setCopyLabel('Copied!')
+      setTimeout(() => setCopyLabel('Share'), 2000)
+    })
   }
 
   const nonEmptyLines = inputText.split('\n').filter(l => l.trim())
@@ -112,6 +122,12 @@ export default function ManualEmbeddingProjector() {
       {/* Header */}
       <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--border)] shrink-0">
         <h2 className="text-sm font-semibold m-0 grow">Manual Branching Projector</h2>
+        <button
+          className="text-xs px-2 py-1 rounded border border-[var(--border)] opacity-60 hover:opacity-100 transition-opacity"
+          onClick={handleShare}
+        >
+          {copyLabel}
+        </button>
         {isDone && (
           <button
             className="text-xs px-2 py-1 rounded border border-[var(--border)] opacity-60 hover:opacity-100 transition-opacity"

--- a/src/ManualEmbeddingProjector.tsx
+++ b/src/ManualEmbeddingProjector.tsx
@@ -14,19 +14,24 @@ const RENDERER_LABELS: Record<RendererType, string> = {
   'glow':        'Glow',
 }
 
-const EXAMPLE_INPUT = `Why
-Why does
-Why does a moon
-Why does a moon rock
-Why does a moon rock taste
-Why does a moon rock taste better
-Why does a moon rock taste better than
-Why does a moon rock taste better than an Earth
-Why does a moon rock taste better than an Earth rock?
-Why does a moon rock taste better than an Earth rock? It's
-Why does a moon rock taste better than an Earth rock? It's a little
-- Why does a moon rock taste better than an Earth rock? It's a little meteor. [space]
-- Why does a moon rock taste better than an Earth rock? It's a little meatier. [taste]`
+const EXAMPLE_INPUT = `What's
+What's the
+What's the best
+What's the best thing
+What's the best thing about
+- What's the best thing about Switzerland [country]?
+  What's the best thing about Switzerland [country]? The
+  What's the best thing about Switzerland [country]? The flag
+  What's the best thing about Switzerland [country]? The flag is
+  What's the best thing about Switzerland [country]? The flag is a
+  What's the best thing about Switzerland [country]? The flag is a big
+  What's the best thing about Switzerland [country]? The flag is a big plus.
+- What's the best thing about Switzerland [country with a cross on its flag]?
+  What's the best thing about Switzerland [country with a cross on its flag]? The flag
+  What's the best thing about Switzerland [country with a cross on its flag]? The flag is
+  What's the best thing about Switzerland [country with a cross on its flag]? The flag is a
+  What's the best thing about Switzerland [country with a cross on its flag]? The flag is a big
+  What's the best thing about Switzerland [country with a cross on its flag]? The flag is a big plus.`
 
 interface ParsedSegment {
   text: string

--- a/src/ManualEmbeddingProjector.tsx
+++ b/src/ManualEmbeddingProjector.tsx
@@ -79,6 +79,16 @@ export default function ManualEmbeddingProjector() {
     setSubmitted(null)
   }
 
+  const nonEmptyLines = inputText.split('\n').filter(l => l.trim())
+  const isMultiline = nonEmptyLines.length > 1
+
+  const handleExpand = () => {
+    if (isMultiline) return
+    const words = inputText.trim().split(/\s+/)
+    if (!words[0]) return
+    setInputText(words.map((_, i) => words.slice(0, i + 1).join(' ')).join('\n'))
+  }
+
   const branchIds = useMemo(
     () => submitted?.map(s => s.branchId) ?? null,
     [submitted]
@@ -113,13 +123,23 @@ export default function ManualEmbeddingProjector() {
           <p className="text-xs opacity-60 m-0">
             Each line = one embedding node. Use <code className="bg-[rgba(255,255,255,0.08)] px-1 rounded">- </code> to start a new branch; indent with spaces to continue it.
           </p>
-          <textarea
-            className="w-full font-mono text-sm rounded border border-[var(--border)] bg-[rgba(255,255,255,0.04)] p-3 resize-y min-h-[220px] focus:outline-none focus:border-[var(--accent-border)]"
-            value={inputText}
-            onChange={e => setInputText(e.target.value)}
-            spellCheck={false}
-            disabled={isRunning}
-          />
+          <div className="relative">
+            <textarea
+              className="w-full font-mono text-sm rounded border border-[var(--border)] bg-[rgba(255,255,255,0.04)] p-3 resize-y min-h-[220px] focus:outline-none focus:border-[var(--accent-border)]"
+              value={inputText}
+              onChange={e => setInputText(e.target.value)}
+              spellCheck={false}
+              disabled={isRunning}
+            />
+            <button
+              className="absolute bottom-2 right-2 text-[11px] px-2 py-[3px] rounded border transition-[background,color,opacity] duration-150 disabled:opacity-30 disabled:cursor-not-allowed border-[var(--border)] bg-black/40 text-white/60 hover:enabled:bg-black/70 hover:enabled:text-white"
+              onClick={handleExpand}
+              disabled={isMultiline || isRunning}
+              title={isMultiline ? 'Already multiline — clear to a single sentence first' : 'Expand sentence word-by-word'}
+            >
+              Expand ↓
+            </button>
+          </div>
 
           <div className="flex items-center gap-3">
             <select

--- a/src/ManualEmbeddingProjector.tsx
+++ b/src/ManualEmbeddingProjector.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import { EMBEDDING_MODELS, type EmbeddingModelId } from './embedSegments'
 import { useEmbeddingWorker } from './useEmbeddingWorker'
 import ScatterPlot3D from './ScatterPlot3D'
@@ -63,13 +63,15 @@ function parseInput(raw: string): ParsedSegment[] {
 }
 
 export default function ManualEmbeddingProjector() {
-  const [inputText, setInputText] = useState(() => readShareParam()?.manualText ?? EXAMPLE_INPUT)
+  const shareParam = readShareParam()
+  const [inputText, setInputText] = useState(() => shareParam?.manualText ?? EXAMPLE_INPUT)
   const [copyLabel, setCopyLabel] = useState<'Share' | 'Copied!'>('Share')
+  const [shareAutoEmbed, setShareAutoEmbed] = useState(false)
   const [selectedModel, setSelectedModel] = useState<EmbeddingModelId>(
     EMBEDDING_MODELS.find(m => m.default)!.id
   )
   const [submitted, setSubmitted] = useState<ParsedSegment[] | null>(null)
-  const [rendererType, setRendererType] = useState<RendererType>('original')
+  const [rendererType, setRendererType] = useState<RendererType>('glow')
   const cameraStateRef = useRef<CameraState | undefined>(undefined)
   const { phase, runEmbedding, cancelEmbedding, resetPhase } = useEmbeddingWorker()
 
@@ -81,13 +83,21 @@ export default function ManualEmbeddingProjector() {
     runEmbedding(segments.map(s => s.text), selectedModel)
   }
 
+  // Auto-embed on load when share URL includes autoEmbed flag
+  useEffect(() => {
+    if (shareParam?.autoEmbed && shareParam.manualText) {
+      handleEmbed()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const handleReset = () => {
     cancelEmbedding()
     setSubmitted(null)
   }
 
   const handleShare = () => {
-    const url = buildShareUrl({ windowSize: 0, overlapPct: 0, manualText: inputText }, '#manual')
+    const url = buildShareUrl({ windowSize: 0, overlapPct: 0, manualText: inputText, autoEmbed: shareAutoEmbed }, '#manual')
     navigator.clipboard.writeText(url).then(() => {
       setCopyLabel('Copied!')
       setTimeout(() => setCopyLabel('Share'), 2000)
@@ -122,6 +132,15 @@ export default function ManualEmbeddingProjector() {
       {/* Header */}
       <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--border)] shrink-0">
         <h2 className="text-sm font-semibold m-0 grow">Manual Branching Projector</h2>
+        <label className="flex items-center gap-1.5 text-xs opacity-60 hover:opacity-100 transition-opacity cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={shareAutoEmbed}
+            onChange={e => setShareAutoEmbed(e.target.checked)}
+            className="accent-[var(--accent-border)]"
+          />
+          auto-embed
+        </label>
         <button
           className="text-xs px-2 py-1 rounded border border-[var(--border)] opacity-60 hover:opacity-100 transition-opacity"
           onClick={handleShare}

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -125,11 +125,27 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
       scene.add(pointsMesh)
 
       if (branchIds) {
-        // Draw a separate line per branch
+        // Draw a separate line per branch.
+        // For non-root branches, prepend the last root node before the branch so
+        // the line visually continues from the branching point.
         const numBranches = Math.max(...branchIds) + 1
         for (let bid = 0; bid < numBranches; bid++) {
-          const indices: number[] = []
-          for (let i = 0; i < n; i++) if (branchIds[i] === bid) indices.push(i)
+          const branchOnly: number[] = []
+          for (let i = 0; i < n; i++) if (branchIds[i] === bid) branchOnly.push(i)
+
+          let indices: number[]
+          if (bid === 0) {
+            indices = branchOnly
+          } else {
+            // Find the last root node that appears before this branch's first node
+            const firstBranchIdx = branchOnly[0]
+            let parentIdx = -1
+            for (let i = firstBranchIdx - 1; i >= 0; i--) {
+              if (branchIds[i] === 0) { parentIdx = i; break }
+            }
+            indices = parentIdx >= 0 ? [parentIdx, ...branchOnly] : branchOnly
+          }
+
           if (indices.length < 2) continue
           const lPos = new Float32Array(indices.length * 3)
           const lCol = new Float32Array(indices.length * 3)
@@ -142,21 +158,6 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
           lg.setAttribute('position', new THREE.BufferAttribute(lPos, 3))
           lg.setAttribute('color', new THREE.BufferAttribute(lCol, 3))
           scene.add(new THREE.Line(lg, new THREE.LineBasicMaterial({ vertexColors: true, opacity: 0.5, transparent: true })))
-        }
-        // Connector lines from each branch's first point → last root point
-        const lastRootIdx = branchIds.lastIndexOf(0)
-        if (lastRootIdx >= 0) {
-          for (let bid = 1; bid < numBranches; bid++) {
-            const firstIdx = branchIds.indexOf(bid)
-            if (firstIdx < 0) continue
-            const cPos = new Float32Array([
-              normalized[lastRootIdx][0], normalized[lastRootIdx][1], normalized[lastRootIdx][2],
-              normalized[firstIdx][0],    normalized[firstIdx][1],    normalized[firstIdx][2],
-            ])
-            const cg = new THREE.BufferGeometry()
-            cg.setAttribute('position', new THREE.BufferAttribute(cPos, 3))
-            scene.add(new THREE.Line(cg, new THREE.LineBasicMaterial({ color: 0xffffff, opacity: 0.2, transparent: true })))
-          }
         }
       } else {
         // Path line through points in transcript order

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -107,7 +107,10 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
         positions[i * 3 + 2] = normalized[i][2]
         let hue: number
         if (branchIds) {
-          hue = BRANCH_HUES[branchIds[i] % BRANCH_HUES.length]
+          // branchId 0 and 1 share the same hue (first branch continues the parent color);
+          // branchId 2+ each get the next distinct hue.
+          const hueIndex = branchIds[i] <= 1 ? 0 : branchIds[i] - 1
+          hue = BRANCH_HUES[hueIndex % BRANCH_HUES.length]
         } else {
           hue = (1 - i / (n - 1)) * 240 // blue→red
         }

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -150,12 +150,17 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
           }
 
           if (indices.length < 2) continue
+          // For non-root branches the first vertex is the prepended parent node.
+          // Use the branch's own color for that vertex so the first edge is solid
+          // (no gradient). The parent dot in the points mesh still shows its own color.
+          const branchColorSrc = bid > 0 ? branchOnly[0] : -1
           const lPos = new Float32Array(indices.length * 3)
           const lCol = new Float32Array(indices.length * 3)
           for (let j = 0; j < indices.length; j++) {
             const idx = indices[j]
+            const colorIdx = (bid > 0 && j === 0) ? branchColorSrc : idx
             lPos[j * 3] = normalized[idx][0]; lPos[j * 3 + 1] = normalized[idx][1]; lPos[j * 3 + 2] = normalized[idx][2]
-            lCol[j * 3] = colors[idx * 3]; lCol[j * 3 + 1] = colors[idx * 3 + 1]; lCol[j * 3 + 2] = colors[idx * 3 + 2]
+            lCol[j * 3] = colors[colorIdx * 3]; lCol[j * 3 + 1] = colors[colorIdx * 3 + 1]; lCol[j * 3 + 2] = colors[colorIdx * 3 + 2]
           }
           const lg = new THREE.BufferGeometry()
           lg.setAttribute('position', new THREE.BufferAttribute(lPos, 3))

--- a/src/ScatterPlot3D.tsx
+++ b/src/ScatterPlot3D.tsx
@@ -3,6 +3,9 @@ import * as THREE from 'three'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 import type { CameraState, FollowMode } from './scatterTypes'
 
+// Distinct hues per branch: blue, orange, green, purple, yellow, cyan, pink, teal
+const BRANCH_HUES = [220, 30, 120, 280, 60, 180, 320, 150]
+
 interface Props {
   points: [number, number, number][]
   labels: string[]
@@ -10,6 +13,8 @@ interface Props {
   onPointClick: (index: number) => void
   initialCameraState?: CameraState
   onCameraChange?: (state: CameraState) => void
+  /** When provided, colors points by branch and draws separate lines per branch */
+  branchIds?: number[]
 }
 
 function normalize(points: [number, number, number][]): [number, number, number][] {
@@ -29,7 +34,7 @@ function normalize(points: [number, number, number][]): [number, number, number]
   )
 }
 
-export default function ScatterPlot3D({ points, labels, highlightPosition, onPointClick, initialCameraState, onCameraChange }: Props) {
+export default function ScatterPlot3D({ points, labels, highlightPosition, onPointClick, initialCameraState, onCameraChange, branchIds }: Props) {
   const mountRef = useRef<HTMLDivElement>(null)
   const sceneRef = useRef<{
     renderer: THREE.WebGLRenderer
@@ -100,7 +105,12 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
         positions[i * 3] = normalized[i][0]
         positions[i * 3 + 1] = normalized[i][1]
         positions[i * 3 + 2] = normalized[i][2]
-        const hue = (1 - i / (n - 1)) * 240 // blue→red
+        let hue: number
+        if (branchIds) {
+          hue = BRANCH_HUES[branchIds[i] % BRANCH_HUES.length]
+        } else {
+          hue = (1 - i / (n - 1)) * 240 // blue→red
+        }
         const color = new THREE.Color().setHSL(hue / 360, 1, 0.55)
         colors[i * 3] = color.r
         colors[i * 3 + 1] = color.g
@@ -114,13 +124,49 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
       const pointsMesh = new THREE.Points(geo, mat)
       scene.add(pointsMesh)
 
-      // Path line through points in transcript order
-      const lineGeo = new THREE.BufferGeometry()
-      lineGeo.setAttribute('position', new THREE.BufferAttribute(positions.slice(), 3))
-      lineGeo.setAttribute('color', new THREE.BufferAttribute(colors.slice(), 3))
-      const lineMat = new THREE.LineBasicMaterial({ vertexColors: true, opacity: 0.35, transparent: true })
-      const lineMesh = new THREE.Line(lineGeo, lineMat)
-      scene.add(lineMesh)
+      if (branchIds) {
+        // Draw a separate line per branch
+        const numBranches = Math.max(...branchIds) + 1
+        for (let bid = 0; bid < numBranches; bid++) {
+          const indices: number[] = []
+          for (let i = 0; i < n; i++) if (branchIds[i] === bid) indices.push(i)
+          if (indices.length < 2) continue
+          const lPos = new Float32Array(indices.length * 3)
+          const lCol = new Float32Array(indices.length * 3)
+          for (let j = 0; j < indices.length; j++) {
+            const idx = indices[j]
+            lPos[j * 3] = normalized[idx][0]; lPos[j * 3 + 1] = normalized[idx][1]; lPos[j * 3 + 2] = normalized[idx][2]
+            lCol[j * 3] = colors[idx * 3]; lCol[j * 3 + 1] = colors[idx * 3 + 1]; lCol[j * 3 + 2] = colors[idx * 3 + 2]
+          }
+          const lg = new THREE.BufferGeometry()
+          lg.setAttribute('position', new THREE.BufferAttribute(lPos, 3))
+          lg.setAttribute('color', new THREE.BufferAttribute(lCol, 3))
+          scene.add(new THREE.Line(lg, new THREE.LineBasicMaterial({ vertexColors: true, opacity: 0.5, transparent: true })))
+        }
+        // Connector lines from each branch's first point → last root point
+        const lastRootIdx = branchIds.lastIndexOf(0)
+        if (lastRootIdx >= 0) {
+          for (let bid = 1; bid < numBranches; bid++) {
+            const firstIdx = branchIds.indexOf(bid)
+            if (firstIdx < 0) continue
+            const cPos = new Float32Array([
+              normalized[lastRootIdx][0], normalized[lastRootIdx][1], normalized[lastRootIdx][2],
+              normalized[firstIdx][0],    normalized[firstIdx][1],    normalized[firstIdx][2],
+            ])
+            const cg = new THREE.BufferGeometry()
+            cg.setAttribute('position', new THREE.BufferAttribute(cPos, 3))
+            scene.add(new THREE.Line(cg, new THREE.LineBasicMaterial({ color: 0xffffff, opacity: 0.2, transparent: true })))
+          }
+        }
+      } else {
+        // Path line through points in transcript order
+        const lineGeo = new THREE.BufferGeometry()
+        lineGeo.setAttribute('position', new THREE.BufferAttribute(positions.slice(), 3))
+        lineGeo.setAttribute('color', new THREE.BufferAttribute(colors.slice(), 3))
+        const lineMat = new THREE.LineBasicMaterial({ vertexColors: true, opacity: 0.35, transparent: true })
+        const lineMesh = new THREE.Line(lineGeo, lineMat)
+        scene.add(lineMesh)
+      }
 
       // Highlight mesh (sphere so it stays visible at any zoom level)
       const hlGeo = new THREE.SphereGeometry(0.04, 16, 16)
@@ -243,7 +289,7 @@ export default function ScatterPlot3D({ points, labels, highlightPosition, onPoi
 
     return () => cleanup?.()
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [points])
+  }, [points, branchIds])
 
   // Highlight updates — set target segment index; RAF lerps along the path each frame
   useEffect(() => {

--- a/src/ScatterPlot3DV5.tsx
+++ b/src/ScatterPlot3DV5.tsx
@@ -3,6 +3,8 @@ import * as THREE from 'three'
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 import type { CameraState, FollowMode } from './scatterTypes'
 
+const BRANCH_HUES = [220, 30, 120, 280, 60, 180, 320, 150]
+
 interface Props {
   points: [number, number, number][]
   labels: string[]
@@ -10,6 +12,7 @@ interface Props {
   onPointClick: (index: number) => void
   initialCameraState?: CameraState
   onCameraChange?: (state: CameraState) => void
+  branchIds?: number[]
 }
 
 function normalize(points: [number, number, number][]): [number, number, number][] {
@@ -50,7 +53,7 @@ function cividis(t: number): THREE.Color {
   return new THREE.Color(r, g, b)
 }
 
-export default function ScatterPlot3DV5({ points, labels, highlightPosition, onPointClick, initialCameraState, onCameraChange }: Props) {
+export default function ScatterPlot3DV5({ points, labels, highlightPosition, onPointClick, initialCameraState, onCameraChange, branchIds }: Props) {
   const mountRef = useRef<HTMLDivElement>(null)
   const sceneRef = useRef<{
     renderer: THREE.WebGLRenderer
@@ -123,7 +126,13 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
         positions[i * 3] = normalized[i][0]
         positions[i * 3 + 1] = normalized[i][1]
         positions[i * 3 + 2] = normalized[i][2]
-        const c = cividis(i / (n - 1))
+        let c: THREE.Color
+        if (branchIds) {
+          const hueIndex = branchIds[i] <= 1 ? 0 : branchIds[i] - 1
+          c = new THREE.Color().setHSL(BRANCH_HUES[hueIndex % BRANCH_HUES.length] / 360, 1, 0.55)
+        } else {
+          c = cividis(i / (n - 1))
+        }
         colors[i * 3] = c.r
         colors[i * 3 + 1] = c.g
         colors[i * 3 + 2] = c.b
@@ -136,40 +145,85 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
       const pointsMesh = new THREE.Points(geo, mat)
       scene.add(pointsMesh)
 
-      // Curved tube path (protein-folding aesthetic).
-      // Use centripetal parameterization so the curve never overshoots or loops
-      // when adjacent segments are far apart in 3D space — prevents the sphere
-      // from visually reversing direction as it follows the curve.
-      const curve = new THREE.CatmullRomCurve3(
-        normalized.map(([x, y, z]) => new THREE.Vector3(x, y, z)),
-        false,
-        'centripetal'
-      )
-
-      const TUBE_SEGMENTS = Math.max(64, normalized.length * 6)
       const RADIAL_SEGMENTS = 10
       const TUBE_RADIUS = 0.025
-
-      const tubeGeo = new THREE.TubeGeometry(curve, TUBE_SEGMENTS, TUBE_RADIUS, RADIAL_SEGMENTS, false)
-
-      const tubeColors = new Float32Array(tubeGeo.attributes.position.count * 3)
       const vertsPerRing = RADIAL_SEGMENTS + 1
-      for (let v = 0; v < tubeGeo.attributes.position.count; v++) {
-        const ring = Math.floor(v / vertsPerRing)
-        const t = ring / TUBE_SEGMENTS
-        const c = cividis(t)
-        // Alternate brightness between node-to-node segments to show spacing
-        const segIdx = Math.floor(Math.min(t * (normalized.length - 1), normalized.length - 2))
-        const bright = segIdx % 2 === 0 ? 1.2 : 0.7
-        tubeColors[v * 3] = Math.min(1, c.r * bright)
-        tubeColors[v * 3 + 1] = Math.min(1, c.g * bright)
-        tubeColors[v * 3 + 2] = Math.min(1, c.b * bright)
-      }
-      tubeGeo.setAttribute('color', new THREE.BufferAttribute(tubeColors, 3))
+      // curve is referenced by sceneRef for highlight sphere follow modes
+      let curve: THREE.CatmullRomCurve3
 
-      const tubeMat = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.6, metalness: 0.1 })
-      const tubeMesh = new THREE.Mesh(tubeGeo, tubeMat)
-      scene.add(tubeMesh)
+      if (branchIds) {
+        // One tube per branch; non-root branches prepend their parent node so the
+        // tube visually starts from the branching point with no gap.
+        const numBranches = Math.max(...branchIds) + 1
+        let rootCurve: THREE.CatmullRomCurve3 | null = null
+        for (let bid = 0; bid < numBranches; bid++) {
+          const branchOnly: number[] = []
+          for (let i = 0; i < n; i++) if (branchIds[i] === bid) branchOnly.push(i)
+          let indices: number[]
+          if (bid === 0) {
+            indices = branchOnly
+          } else {
+            const firstBranchIdx = branchOnly[0]
+            let parentIdx = -1
+            for (let i = firstBranchIdx - 1; i >= 0; i--) {
+              if (branchIds[i] === 0) { parentIdx = i; break }
+            }
+            indices = parentIdx >= 0 ? [parentIdx, ...branchOnly] : branchOnly
+          }
+          if (indices.length < 2) continue
+          const hueIndex = bid <= 1 ? 0 : bid - 1
+          const baseColor = new THREE.Color().setHSL(BRANCH_HUES[hueIndex % BRANCH_HUES.length] / 360, 1, 0.55)
+          const branchCurve = new THREE.CatmullRomCurve3(
+            indices.map(idx => new THREE.Vector3(...normalized[idx])),
+            false, 'centripetal'
+          )
+          if (bid === 0) rootCurve = branchCurve
+          const branchTubeSegs = Math.max(64, indices.length * 6)
+          const tubeGeo = new THREE.TubeGeometry(branchCurve, branchTubeSegs, TUBE_RADIUS, RADIAL_SEGMENTS, false)
+          const tubeColors = new Float32Array(tubeGeo.attributes.position.count * 3)
+          for (let v = 0; v < tubeGeo.attributes.position.count; v++) {
+            const ring = Math.floor(v / vertsPerRing)
+            const t = ring / branchTubeSegs
+            const segIdx = Math.floor(Math.min(t * (indices.length - 1), indices.length - 2))
+            const bright = segIdx % 2 === 0 ? 1.2 : 0.7
+            tubeColors[v * 3] = Math.min(1, baseColor.r * bright)
+            tubeColors[v * 3 + 1] = Math.min(1, baseColor.g * bright)
+            tubeColors[v * 3 + 2] = Math.min(1, baseColor.b * bright)
+          }
+          tubeGeo.setAttribute('color', new THREE.BufferAttribute(tubeColors, 3))
+          scene.add(new THREE.Mesh(tubeGeo, new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.6, metalness: 0.1 })))
+        }
+        // Provide a valid curve for sceneRef (only accessed when highlight sphere is visible)
+        curve = rootCurve ?? new THREE.CatmullRomCurve3(
+          [new THREE.Vector3(...normalized[0]), new THREE.Vector3(...normalized[0])],
+          false, 'centripetal'
+        )
+      } else {
+        // Curved tube path (protein-folding aesthetic).
+        // Use centripetal parameterization so the curve never overshoots or loops
+        // when adjacent segments are far apart in 3D space — prevents the sphere
+        // from visually reversing direction as it follows the curve.
+        curve = new THREE.CatmullRomCurve3(
+          normalized.map(([x, y, z]) => new THREE.Vector3(x, y, z)),
+          false, 'centripetal'
+        )
+        const TUBE_SEGMENTS = Math.max(64, normalized.length * 6)
+        const tubeGeo = new THREE.TubeGeometry(curve, TUBE_SEGMENTS, TUBE_RADIUS, RADIAL_SEGMENTS, false)
+        const tubeColors = new Float32Array(tubeGeo.attributes.position.count * 3)
+        for (let v = 0; v < tubeGeo.attributes.position.count; v++) {
+          const ring = Math.floor(v / vertsPerRing)
+          const t = ring / TUBE_SEGMENTS
+          const c = cividis(t)
+          // Alternate brightness between node-to-node segments to show spacing
+          const segIdx = Math.floor(Math.min(t * (normalized.length - 1), normalized.length - 2))
+          const bright = segIdx % 2 === 0 ? 1.2 : 0.7
+          tubeColors[v * 3] = Math.min(1, c.r * bright)
+          tubeColors[v * 3 + 1] = Math.min(1, c.g * bright)
+          tubeColors[v * 3 + 2] = Math.min(1, c.b * bright)
+        }
+        tubeGeo.setAttribute('color', new THREE.BufferAttribute(tubeColors, 3))
+        scene.add(new THREE.Mesh(tubeGeo, new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.6, metalness: 0.1 })))
+      }
 
       // Lighting for MeshStandardMaterial
       scene.add(new THREE.AmbientLight(0xffffff, 0.7))
@@ -278,7 +332,7 @@ export default function ScatterPlot3DV5({ points, labels, highlightPosition, onP
 
     return () => cleanup?.()
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [points])
+  }, [points, branchIds])
 
   // Highlight updates — set target position on curve; RAF lerps sphere towards it each frame
   useEffect(() => {

--- a/src/ScatterPlot3DV6.tsx
+++ b/src/ScatterPlot3DV6.tsx
@@ -7,6 +7,8 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js'
 import type { CameraState, FollowMode } from './scatterTypes'
 
+const BRANCH_HUES = [220, 30, 120, 280, 60, 180, 320, 150]
+
 interface Props {
   points: [number, number, number][]
   labels: string[]
@@ -17,6 +19,7 @@ interface Props {
   fillBrightness?: number // brightness multiplier for fill particles (default 1)
   initialCameraState?: CameraState
   onCameraChange?: (state: CameraState) => void
+  branchIds?: number[]
 }
 
 function normalize(points: [number, number, number][]): [number, number, number][] {
@@ -101,7 +104,7 @@ void main() {
 }
 `
 
-export default function ScatterPlot3DV6({ points, labels, highlightPosition, onPointClick, fillPerSeg = 12, fillJitter = 0.03, fillBrightness = 1.8, initialCameraState, onCameraChange }: Props) {
+export default function ScatterPlot3DV6({ points, labels, highlightPosition, onPointClick, fillPerSeg = 12, fillJitter = 0.03, fillBrightness = 1.8, initialCameraState, onCameraChange, branchIds }: Props) {
   const mountRef = useRef<HTMLDivElement>(null)
   const sceneRef = useRef<{
     renderer: THREE.WebGLRenderer
@@ -176,7 +179,13 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
         positions[i * 3] = normalized[i][0]
         positions[i * 3 + 1] = normalized[i][1]
         positions[i * 3 + 2] = normalized[i][2]
-        const c = glowPalette(i / (n - 1))
+        let c: THREE.Color
+        if (branchIds) {
+          const hueIndex = branchIds[i] <= 1 ? 0 : branchIds[i] - 1
+          c = new THREE.Color().setHSL(BRANCH_HUES[hueIndex % BRANCH_HUES.length] / 360, 1, 0.7)
+        } else {
+          c = glowPalette(i / (n - 1))
+        }
         aColors[i * 3] = c.r
         aColors[i * 3 + 1] = c.g
         aColors[i * 3 + 2] = c.b
@@ -200,19 +209,49 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
       const pointsMesh = new THREE.Points(geo, mat)
       scene.add(pointsMesh)
 
-      // Fill particles — interpolated between adjacent nodes with optional jitter
-      const fillCount = (n - 1) * fillPerSeg
+      // Fill particles — interpolated between adjacent nodes with optional jitter.
+      // With branchIds, only fill within each branch's own segments so particles
+      // don't cross branch boundaries.
+      type FillSegment = { from: number; to: number; color: THREE.Color | null }
+      const fillSegments: FillSegment[] = []
+      if (branchIds) {
+        const numBranches = Math.max(...branchIds) + 1
+        for (let bid = 0; bid < numBranches; bid++) {
+          const branchOnly: number[] = []
+          for (let i = 0; i < n; i++) if (branchIds[i] === bid) branchOnly.push(i)
+          let indices: number[]
+          if (bid === 0) {
+            indices = branchOnly
+          } else {
+            const firstBranchIdx = branchOnly[0]
+            let parentIdx = -1
+            for (let i = firstBranchIdx - 1; i >= 0; i--) {
+              if (branchIds[i] === 0) { parentIdx = i; break }
+            }
+            indices = parentIdx >= 0 ? [parentIdx, ...branchOnly] : branchOnly
+          }
+          const hueIndex = bid <= 1 ? 0 : bid - 1
+          const branchColor = new THREE.Color().setHSL(BRANCH_HUES[hueIndex % BRANCH_HUES.length] / 360, 1, 0.7)
+          for (let j = 0; j < indices.length - 1; j++) {
+            fillSegments.push({ from: indices[j], to: indices[j + 1], color: branchColor })
+          }
+        }
+      } else {
+        for (let i = 0; i < n - 1; i++) fillSegments.push({ from: i, to: i + 1, color: null })
+      }
+      const fillCount = fillSegments.length * fillPerSeg
       const fillPositions = new Float32Array(fillCount * 3)
       const fillColors = new Float32Array(fillCount * 3)
       const fillSeeds = new Float32Array(fillCount)
-      for (let i = 0; i < n - 1; i++) {
+      for (let si = 0; si < fillSegments.length; si++) {
+        const { from, to, color } = fillSegments[si]
         for (let j = 0; j < fillPerSeg; j++) {
           const f = (j + 1) / (fillPerSeg + 1)
-          const idx = i * fillPerSeg + j
-          fillPositions[idx * 3]     = normalized[i][0] + (normalized[i + 1][0] - normalized[i][0]) * f + (Math.random() - 0.5) * 2 * fillJitter
-          fillPositions[idx * 3 + 1] = normalized[i][1] + (normalized[i + 1][1] - normalized[i][1]) * f + (Math.random() - 0.5) * 2 * fillJitter
-          fillPositions[idx * 3 + 2] = normalized[i][2] + (normalized[i + 1][2] - normalized[i][2]) * f + (Math.random() - 0.5) * 2 * fillJitter
-          const c = glowPalette((i + f) / (n - 1))
+          const idx = si * fillPerSeg + j
+          fillPositions[idx * 3]     = normalized[from][0] + (normalized[to][0] - normalized[from][0]) * f + (Math.random() - 0.5) * 2 * fillJitter
+          fillPositions[idx * 3 + 1] = normalized[from][1] + (normalized[to][1] - normalized[from][1]) * f + (Math.random() - 0.5) * 2 * fillJitter
+          fillPositions[idx * 3 + 2] = normalized[from][2] + (normalized[to][2] - normalized[from][2]) * f + (Math.random() - 0.5) * 2 * fillJitter
+          const c = color ?? glowPalette((from + f) / (n - 1))
           fillColors[idx * 3] = c.r; fillColors[idx * 3 + 1] = c.g; fillColors[idx * 3 + 2] = c.b
           fillSeeds[idx] = Math.random()
         }
@@ -366,7 +405,7 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
 
     return () => cleanup?.()
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [points, fillPerSeg, fillJitter, fillBrightness])
+  }, [points, fillPerSeg, fillJitter, fillBrightness, branchIds])
 
   // Highlight updates — set target segment index; RAF lerps along the path each frame
   useEffect(() => {

--- a/src/ScatterPlot3DV6.tsx
+++ b/src/ScatterPlot3DV6.tsx
@@ -58,6 +58,7 @@ function glowPalette(t: number): THREE.Color {
 const vertexShader = /* glsl */`
 attribute vec3 aColor;
 attribute float aSeed;
+uniform float uScale;
 varying vec3 vColor;
 varying float vSeed;
 
@@ -65,8 +66,8 @@ void main() {
   vColor = aColor;
   vSeed = aSeed;
   vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
-  // Size scales with camera distance; random seed adds per-point variation
-  gl_PointSize = (1.5 + 2.5 / -mvPosition.z) * (0.6 + 0.8 * aSeed);
+  // Size scales with camera distance, canvas size (uScale), and random seed variation
+  gl_PointSize = (2.5 + 5.0 / -mvPosition.z) * (0.6 + 0.8 * aSeed) * uScale;
   gl_Position = projectionMatrix * mvPosition;
 }
 `
@@ -75,6 +76,7 @@ void main() {
 const fillVertexShader = /* glsl */`
 attribute vec3 aColor;
 attribute float aSeed;
+uniform float uScale;
 varying vec3 vColor;
 varying float vSeed;
 
@@ -82,7 +84,7 @@ void main() {
   vColor = aColor;
   vSeed = aSeed;
   vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
-  gl_PointSize = (0.7 + 1.2 / -mvPosition.z) * (0.4 + 0.6 * aSeed);
+  gl_PointSize = (1.2 + 2.5 / -mvPosition.z) * (0.4 + 0.6 * aSeed) * uScale;
   gl_Position = projectionMatrix * mvPosition;
 }
 `
@@ -104,7 +106,7 @@ void main() {
 }
 `
 
-export default function ScatterPlot3DV6({ points, labels, highlightPosition, onPointClick, fillPerSeg = 12, fillJitter = 0.03, fillBrightness = 1.8, initialCameraState, onCameraChange, branchIds }: Props) {
+export default function ScatterPlot3DV6({ points, labels, highlightPosition, onPointClick, fillPerSeg = 20, fillJitter = 0.03, fillBrightness = 1.8, initialCameraState, onCameraChange, branchIds }: Props) {
   const mountRef = useRef<HTMLDivElement>(null)
   const sceneRef = useRef<{
     renderer: THREE.WebGLRenderer
@@ -197,7 +199,8 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
       geo.setAttribute('aColor', new THREE.BufferAttribute(aColors, 3))
       geo.setAttribute('aSeed', new THREE.BufferAttribute(aSeeds, 1))
 
-      const uniforms = { uTime: { value: 0 }, uBrightness: { value: 1.0 } }
+      const canvasScale = Math.max(1.0, h / 500.0)
+      const uniforms = { uTime: { value: 0 }, uBrightness: { value: 1.0 }, uScale: { value: canvasScale } }
       const mat = new THREE.ShaderMaterial({
         uniforms,
         vertexShader,
@@ -260,9 +263,9 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
       fillGeo.setAttribute('position', new THREE.BufferAttribute(fillPositions, 3))
       fillGeo.setAttribute('aColor',   new THREE.BufferAttribute(fillColors, 3))
       fillGeo.setAttribute('aSeed',    new THREE.BufferAttribute(fillSeeds, 1))
-      // Share uTime with node material; use fillBrightness for fill-specific brightness
+      // Share uTime and uScale with node material; use fillBrightness for fill-specific brightness
       const fillMat = new THREE.ShaderMaterial({
-        uniforms: { uTime: uniforms.uTime, uBrightness: { value: fillBrightness } },
+        uniforms: { uTime: uniforms.uTime, uBrightness: { value: fillBrightness }, uScale: uniforms.uScale },
         vertexShader: fillVertexShader,
         fragmentShader,
         transparent: true,
@@ -278,10 +281,10 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
       highlightMesh.visible = false
       scene.add(highlightMesh)
 
-      // Post-processing: bloom
+      // Post-processing: bloom — strength and radius adapt to camera distance in animate loop
       const composer = new EffectComposer(renderer)
       composer.addPass(new RenderPass(scene, camera))
-      const bloomPass = new UnrealBloomPass(new THREE.Vector2(w, h), 1.2, 0.5, 0.15)
+      const bloomPass = new UnrealBloomPass(new THREE.Vector2(w, h), 1.5, 0.6, 0.10)
       composer.addPass(bloomPass)
       composer.addPass(new OutputPass())
 
@@ -293,6 +296,11 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
       const animate = () => {
         animId = requestAnimationFrame(animate)
         uniforms.uTime.value += 0.016
+        // Adapt bloom strength to camera distance — farther away = weaker glow per pixel,
+        // so compensate by boosting strength as zoom increases.
+        const camDist = camera.position.distanceTo(controls.target)
+        bloomPass.strength = Math.max(1.0, 1.5 * (camDist / 4.0))
+        bloomPass.radius = Math.min(1.0, 0.5 + 0.08 * (camDist / 4.0))
         // Lerp the segment index so the sphere travels along the piecewise-linear path.
         // On the first visible frame, snap to target and seed prevFollowTargetRef.
         if (sphereVisibleRef.current) {
@@ -371,6 +379,8 @@ export default function ScatterPlot3DV6({ points, labels, highlightPosition, onP
         composer.setSize(nw, nh)
         camera.aspect = nw / nh
         camera.updateProjectionMatrix()
+        // Scale particle sizes with canvas height so they stay visually consistent
+        uniforms.uScale.value = Math.max(1.0, nh / 500.0)
       })
       ro.observe(mount)
 

--- a/src/embedSegments.ts
+++ b/src/embedSegments.ts
@@ -2,8 +2,8 @@
 type AnyPipeline = any
 
 export const EMBEDDING_MODELS = [
-  { id: 'Xenova/all-MiniLM-L6-v2',                      label: 'MiniLM-L6 (fast, ~22 MB)',         default: true },
-  { id: 'Xenova/all-MiniLM-L12-v2',                     label: 'MiniLM-L12 (balanced, ~33 MB)',    default: false },
+  { id: 'Xenova/all-MiniLM-L6-v2',                      label: 'MiniLM-L6 (fast, ~22 MB)',         default: false },
+  { id: 'Xenova/all-MiniLM-L12-v2',                     label: 'MiniLM-L12 (balanced, ~33 MB)',    default: true },
   { id: 'Xenova/all-mpnet-base-v2',                      label: 'MPNet-base (quality, ~420 MB)',    default: false },
   { id: 'Xenova/paraphrase-multilingual-MiniLM-L12-v2', label: 'Multilingual MiniLM (~125 MB)',    default: false },
 ] as const

--- a/src/shareUrl.ts
+++ b/src/shareUrl.ts
@@ -8,6 +8,7 @@ export interface SharePayload {
   rendererType?: string
   rawText?: string
   points?: [number, number, number][]
+  manualText?: string
 }
 
 export function encodeSharePayload(payload: SharePayload): string {

--- a/src/shareUrl.ts
+++ b/src/shareUrl.ts
@@ -9,6 +9,7 @@ export interface SharePayload {
   rawText?: string
   points?: [number, number, number][]
   manualText?: string
+  autoEmbed?: boolean
 }
 
 export function encodeSharePayload(payload: SharePayload): string {


### PR DESCRIPTION
## Summary

- New `#manual` view: type lines of text, one embedding node per line; prefix with `- ` to start a branch, indent to continue it
- Branches render as distinct colored paths, each visually continuing from the branching point
- Renderer toggle (Points / Tube / Glow) with Glow as default; camera position preserved when switching renderers
- Glow renderer made adaptive: particle sizes scale with canvas height, fill density increased, bloom adapts to camera distance
- Word-by-word sentence expander button in the textarea (disabled when already multiline)
- Share button with pako-compressed `?share=` URL; optional "auto-embed" checkbox to trigger embedding on load
- Default model changed to MiniLM-L12 (balanced) across all views
- Updated example: Switzerland flag joke with two branches diverging on context

## Test plan

- [ ] Load `#manual`, verify Switzerland example appears and Glow renderer is active
- [ ] Embed the example and confirm two branches render with distinct colors
- [ ] Switch renderers and confirm camera position is preserved
- [ ] Test Expand button: paste a single sentence, click Expand, verify word-by-word output; confirm button is disabled when textarea has multiple lines
- [ ] Click Share, confirm URL is copied; open URL and verify text is restored
- [ ] Check Share with "auto-embed" checked: opening the URL should start embedding automatically
- [ ] Confirm MiniLM-L12 is selected by default in all embedding views

🤖 Generated with [Claude Code](https://claude.com/claude-code)